### PR TITLE
6 initial cd

### DIFF
--- a/bash-emu.py
+++ b/bash-emu.py
@@ -1,9 +1,11 @@
-from com.common import clear, ls, mv, rm
+from com.common import clear, ls, mv, rm, cd
 from typing import List
 from com.help import help
+from util.RemarkableWorkspace import remarkable_workspace as workspace
 
 while True:
-    user_input: List[str] = input("remarkable$ ").split(' ')
+    path = workspace.get_current_path()
+    user_input: List[str] = input(f"remarkable~{path}$ ").split(' ')
     
     if not user_input:
         continue
@@ -11,8 +13,12 @@ while True:
     command, *args = user_input
 
     match command:
+        case "cd":
+            cd(args)
         case "clear":
             clear()
+        case "rm":
+            rm(args)
         case "ls":
             ls(args)
         case "mv":
@@ -22,4 +28,4 @@ while True:
         case "exit" | "x":
             break
         case _:
-            print("Unknown com. Type help for a list of supported commands")
+            print("Unknown command. Type help for a list of supported commands")

--- a/com/common.py
+++ b/com/common.py
@@ -4,9 +4,11 @@ from typing import List, Dict
 from util.RemarkableWorkspace import remarkable_workspace as workspace
 
 def cd(args: List[str]) -> None:
-    path = ' '.join(args)
+    path = ''
+    if args:
+        path = ' '.join(args)
     match path:
-        case "/":
+        case "":
             workspace.set_current_collection('')
         case "..":
             workspace.set_current_collection(workspace.get_parent())

--- a/com/common.py
+++ b/com/common.py
@@ -1,9 +1,21 @@
 import subprocess
 from typing import List, Dict
 
-from util.RemarkableWorkspace import RemarkableWorkspace
+from util.RemarkableWorkspace import remarkable_workspace as workspace
 
-workspace = RemarkableWorkspace()
+def cd(args: List[str]) -> None:
+    path = ' '.join(args)
+    match path:
+        case "/":
+            workspace.set_current_collection('')
+        case "..":
+            workspace.set_current_collection(workspace.get_parent())
+        case _:
+            collection = workspace.get_collection(path)
+            if collection:
+                workspace.set_current_collection(collection)
+            else:
+                print("Invalid path")
 
 def mv(args: List[str]) -> None:
     """
@@ -41,11 +53,11 @@ def ls(args: List[str]) -> None:
 
     result = []
     for uuid, v in remarkable_metadata.items():
-        if remarkable_metadata[uuid].get('parent') is not workspace.get_current_collection():
+        if remarkable_metadata[uuid].get('parent') != workspace.get_current_collection():
             continue
         path_and_file = recurse_path(uuid, remarkable_metadata)
         if remarkable_metadata[uuid].get('size'):
-            path_and_file += ' ' + str(remarkable_metadata[uuid].get('size'))
+            path_and_file = str(remarkable_metadata[uuid].get('size')) + '\t' + path_and_file
         result.append(path_and_file)
 
     for e in sorted(result):
@@ -59,6 +71,8 @@ def clear():
 def recurse_path(uuid: str, remarkable_metadata: Dict) -> str:
     """
     A helper method to find the path for each entity.
+
+    TODO: remove when code uses workspace implementation of this
 
     :param uuid: entity's uuid
     :param remarkable_metadata: a reference to the dictionary of metadata

--- a/util/RemarkableWorkspace.py
+++ b/util/RemarkableWorkspace.py
@@ -65,7 +65,7 @@ class RemarkableWorkspace:
                 uuid = (
                     member.name
                     .removeprefix("./")
-                    .removesuffix(".remarkable_file_data")
+                    .removesuffix(".metadata")
                 )
                 data[uuid] = metadata
 
@@ -151,3 +151,66 @@ class RemarkableWorkspace:
         :return: a UUID of the current collection
         """
         return self._current_collection
+
+    def set_current_collection(self, collection: str) -> None:
+        """
+        Setter for the current collection. The collection
+        must be either an UUID of a CollectionType or an
+        empty string for root.
+
+        :return: None
+        """
+        is_root = collection == ''
+        is_valid_collection = self._data.get(collection) and self._data[collection].get('type') == 'CollectionType'
+        if not (is_root or is_valid_collection):
+            # TODO: think about this. Should this lead to exception or be handled more gracefully?
+            raise Exception("Invalid Collection")
+        self._current_collection = collection
+
+
+    def get_parent(self) -> str:
+        return self._data[self._current_collection].get('parent')
+
+    def get_collection(self, collection: str) -> Optional[str]:
+        """
+        As a first version returns the uuid of the collection with the current parent
+        and a matching visible name
+        :param collection: a name of the collection
+        :return: an optional UUID of the collection
+        """
+        for k, v in self._data.items():
+            if v.get('parent') != self._current_collection:
+                continue
+            if v.get('type') == 'CollectionType' and v.get('visibleName') == collection:
+                return k
+        return None
+
+    def get_current_path(self) -> str:
+        if self._current_collection == '':
+            return "/"
+        return self.recurse_collection_path(self._current_collection)
+
+    def recurse_collection_path(self, uuid: str) -> str:
+        """
+        A helper method to find the path for each entity.
+
+        :param uuid: entity's uuid
+        :param remarkable_metadata: a reference to the dictionary of metadata
+        :return: a string representation of the path
+        """
+
+        if not self._data.get(uuid):
+            return './<NA>'
+
+        # print(f"data for {uuid}: {remarkable_metadata.get(uuid)}")
+        if self._data[uuid].get('parent') == '':
+            return "./" + self._data[uuid]['visibleName']
+
+        if self._data[uuid].get('parent') == 'trash':
+            return './trash/' + self._data[uuid].get('visibleName')
+
+        return self.recurse_collection_path(self._data[uuid]['parent']) + "/" + self._data[uuid].get('visibleName')
+
+
+
+remarkable_workspace = RemarkableWorkspace()


### PR DESCRIPTION
Created an initial version of `cd`. For now the following variations work: 

- `cd ..`: traverses to parent path. In root does nothing
- `cd <path>`: traverses to subpath
- `cd`: traverses to root path 

No unittests have been yet written. I think I'll create the basic core functionalities, including `mv` and `rm` first and then I'll start writing unittests. 