### PR TITLE
22 add rest of missing unittests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ Generate HTML-report:
 ```bash
 coverage html
 ```
+
+And for convenience: 
+```bash
+coverage run --source=src -m pytest && coverage html && xdg-open htmlcov/index.html
+```

--- a/bash-emu.py
+++ b/bash-emu.py
@@ -1,31 +1,39 @@
 from src.com.common import clear, ls, mv, rm, cd
 from typing import List
 from src.com.help import help_instruction
-from src.util.RemarkableWorkspaceOLD import remarkable_workspace as workspace
+from src.workspace.workspace_manager import default_workspace_manager as workspace_manager
 
-while True:
-    path = workspace.get_current_path()
-    user_input: List[str] = input(f"remarkable~{path}$ ").split(' ')
-    
-    if not user_input:
-        continue
-    
-    command, *args = user_input
+def main_loop() -> None:
 
-    match command:
-        case "cd":
-            cd(args)
-        case "clear":
-            clear()
-        case "rm":
-            rm(args)
-        case "ls":
-            ls(args)
-        case "mv":
-            mv(args)
-        case "help":
-            help_instruction()
-        case "exit" | "x":
-            break
-        case _:
-            print("Unknown command. Type help for a list of supported commands")
+    ws = workspace_manager.get()
+
+    while True:
+        path = ws.get_current_path()
+        user_input: List[str] = input(f"remarkable~{path}$ ").split(' ')
+
+        if not user_input:
+            continue
+
+        command, *args = user_input
+
+        match command:
+            case "cd":
+                cd(args, workspace_manager)
+            case "clear":
+                clear()
+            case "rm":
+                rm(args)
+            case "ls":
+                ls(args, workspace_manager)
+            case "mv":
+                mv(args)
+            case "help":
+                help_instruction()
+            case "exit" | "x":
+                break
+            case _:
+                print("Unknown command. Type help for a list of supported commands")
+
+
+if __name__ == "__main__":
+    pass

--- a/src/com/common.py
+++ b/src/com/common.py
@@ -72,7 +72,7 @@ def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
     for uuid, v in remarkable_metadata.items():
         if v.get('parent') != ws.get_current_collection():
             continue
-        path_and_file = recurse_path(uuid, remarkable_metadata)
+        path_and_file = ws.generate_absolute_collection_path(uuid)
         if v.get('size'):
             path_and_file = str(v.get('size')) + '\t' + path_and_file
         result.append(path_and_file)
@@ -86,27 +86,3 @@ def clear() -> None:
     :return: None
     """
     subprocess.run("clear", check=False)
-
-def recurse_path(uuid: str, remarkable_metadata: Dict) -> str:
-    """
-    A helper method to find the path for each entity.
-
-    TODO: remove when code uses workspace implementation of this
-
-    :param uuid: entity's uuid
-    :param remarkable_metadata: a reference to the dictionary of metadata
-    :return: a string representation of the path
-    """
-
-    if not remarkable_metadata.get(uuid):
-        return './<NA>'
-
-    # print(f"data for {uuid}: {remarkable_metadata.get(uuid)}")
-    if remarkable_metadata[uuid].get('parent') == '':
-        return "./" + remarkable_metadata[uuid]['visibleName']
-
-    if remarkable_metadata[uuid].get('parent') == 'trash':
-        return './trash/' + remarkable_metadata[uuid].get('visibleName')
-
-    return  recurse_path(remarkable_metadata[uuid]['parent'],
-                         remarkable_metadata) + "/" + remarkable_metadata[uuid].get('visibleName')

--- a/src/com/common.py
+++ b/src/com/common.py
@@ -7,24 +7,27 @@ import subprocess
 from typing import List, Dict
 
 from src.constant import ROOT_COLLECTION
+from src.workspace.workspace_manager import WorkspaceManager
 
-from src.util.RemarkableWorkspaceOLD import remarkable_workspace as workspace
 
-
-def cd(args: List[str]) -> None:
+def cd(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     Instruction for change directory command
 
     :param args: the path to which directory should be changed to
+    :param workspace_manager: manager for reMarkable workspace
     :return: None
     """
+
+    ws = workspace_manager.get()
+
     if len(args) == 0:
-        workspace.set_current_collection(ROOT_COLLECTION)
+        ws.set_current_collection(ROOT_COLLECTION)
     elif len(args) > 1:
         print("Usage: cd OR cd <path>")
         return
     else:
-        workspace.change_collection(args[0])
+        ws.change_collection(args[0])
 
 def mv(args: List[str]) -> None:
     """
@@ -49,22 +52,25 @@ def rm(args: List[str]) -> None:
     """
     print(f"Remove not implemented. Called with args: {args}")
 
-def ls(args: List[str]) -> None:
+def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of the list command.
 
     TODO: add support for args
 
     :param args: arguments for the ls command
+    :param workspace_manager: manager for reMarkable workspace
     :return: None
     """
-    remarkable_metadata = workspace.get_data()
+    ws = workspace_manager.get()
+
+    remarkable_metadata = ws.get_data()
 
     print(f"List called with args: {args}")
 
     result = []
     for uuid, v in remarkable_metadata.items():
-        if v.get('parent') != workspace.get_current_collection():
+        if v.get('parent') != ws.get_current_collection():
             continue
         path_and_file = recurse_path(uuid, remarkable_metadata)
         if v.get('size'):

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -20,6 +20,15 @@ class RemarkableWorkspace:
         self._data = metadata
         self._current_collection = ''
 
+
+    def get_data(self) -> Dict[str, Dict[str, Any]]:
+        """
+        A getter for the reMarkable filedata
+
+        :return: a dictionary of Remarkable file data
+        """
+        return self._data  # type: ignore
+
     def get_current_collection(self) -> str:
         """
         A getter for the current collection. An empty string

--- a/src/workspace/workspace_manager.py
+++ b/src/workspace/workspace_manager.py
@@ -5,6 +5,7 @@
 from typing import Optional
 
 from src.data.metadata_source import MetadataSource
+from src.data.remarkable_ssh_metadata_source import RemarkableSSHMetadataSource
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 
 class WorkspaceManager:
@@ -39,3 +40,6 @@ class WorkspaceManager:
         """
         self._workspace = RemarkableWorkspace(self._source.load())
         return self._workspace
+
+
+default_workspace_manager = WorkspaceManager(RemarkableSSHMetadataSource())

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -1,11 +1,10 @@
 import unittest
-
-from test.test_data import TEST_DATA
+from io import StringIO
+from unittest.mock import patch, MagicMock
 
 from src.com.common import cd, ls, mv, rm, clear
 from test.stub_remarkable_metadata_source import StubRemarkableMetadataSource
 from src.workspace.workspace_manager import WorkspaceManager
-from src.workspace.remarkable_workspace import RemarkableWorkspace
 
 class TestCommon(unittest.TestCase):
 
@@ -16,6 +15,7 @@ class TestCommon(unittest.TestCase):
         self.manager = WorkspaceManager(StubRemarkableMetadataSource())
         self.ws = self.manager.get()
 
+    # cd instruction
     def test_cd_without_args_sets_current_path_to_root(self) -> None:
         self.ws.set_current_collection("a")
         cd([], self.manager)
@@ -35,3 +35,78 @@ class TestCommon(unittest.TestCase):
         cd(["A"], self.manager)
         self.assertTrue(self.ws.get_current_collection() == "a")
 
+
+    def test_cd_with_too_many_args(self) -> None:
+        self.ws.set_current_collection("")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            cd(["arg1", "arg2"], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("Usage: cd OR cd <path>" in output, msg=f"Output was: {output}")
+
+
+    # ls instruction
+    def test_ls_root(self) -> None:
+        self.ws.set_current_collection("")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            ls([], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("/A" in output, msg=f"Output was: {output}")
+            self.assertTrue("/B" in output, msg=f"Output was: {output}")
+
+    def test_ls_sub_path(self) -> None:
+        self.ws.set_current_collection("a")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            ls([], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("/A_0" in output, msg=f"Output was: {output}")
+
+    def test_ls_file_with_size(self) -> None:
+        self.ws.set_current_collection("a")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            ls([], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("1024 kB" in output, msg=f"Output was: {output}")
+            self.assertTrue("/A/Fairytale.pdf" in output, msg=f"Output was: {output}")
+
+
+    # clear instruction
+    @patch("src.com.common.subprocess.run")
+    def test_clear(self, mock_run: MagicMock) -> None:
+        """
+        Verifies that clear() invokes subprocess.run with "clear".
+
+        mock_run is the MagicMock injected by unittest.mock.patch,
+        replacing src.com.common.subprocess.run.
+
+        refrence: https://docs.python.org/3/library/unittest.mock.html
+        """
+        clear()
+        mock_run.assert_called_once_with("clear", check=False)
+
+
+    # mv instruction
+    def test_mv(self) -> None:
+        """
+        Move instruction is not yet implemented. This test will
+        break when the implementation occurs. A useful remainder
+        to update tests.
+        """
+        self.ws.set_current_collection("")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            mv([])
+            output: str = mock_out.getvalue()
+            self.assertTrue("Move not implemented." in output, msg=f"Output was: {output}")
+
+
+    # rm instruction
+    def test_rm(self) -> None:
+        """
+        Move instruction is not yet implemented. This test will
+        break when the implementation occurs. A useful remainder
+        to update tests.
+        """
+        self.ws.set_current_collection("")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            rm([])
+            output: str = mock_out.getvalue()
+            self.assertTrue("Remove not implemented." in output, msg=f"Output was: {output}")

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -1,0 +1,37 @@
+import unittest
+
+from test.test_data import TEST_DATA
+
+from src.com.common import cd, ls, mv, rm, clear
+from test.stub_remarkable_metadata_source import StubRemarkableMetadataSource
+from src.workspace.workspace_manager import WorkspaceManager
+from src.workspace.remarkable_workspace import RemarkableWorkspace
+
+class TestCommon(unittest.TestCase):
+
+    def setUp(self) -> None:
+        # In python overriding private attributes is possible. Here
+        # we abuse this capability to set the test data to the workspace
+
+        self.manager = WorkspaceManager(StubRemarkableMetadataSource())
+        self.ws = self.manager.get()
+
+    def test_cd_without_args_sets_current_path_to_root(self) -> None:
+        self.ws.set_current_collection("a")
+        cd([], self.manager)
+        self.assertTrue(self.ws.get_current_collection() == "")
+
+    def test_cd_to_subpath_works(self) -> None:
+        """
+        Verifies that changing collection to a direct subcollection
+        works. The intention is to verify that all paths in cd-method
+        work as intended.
+
+        Note: Change directory is tested more comprehensively in
+        RemarkableWorkspace test suite
+        :return: None
+        """
+        self.ws.set_current_collection("")
+        cd(["A"], self.manager)
+        self.assertTrue(self.ws.get_current_collection() == "a")
+

--- a/test/com/test_help.py
+++ b/test/com/test_help.py
@@ -1,0 +1,15 @@
+import unittest
+from io import StringIO
+from unittest.mock import patch
+from src.com.help import help_instruction
+
+
+class TestHelpInstruction(unittest.TestCase):
+
+    def test_help_method_prints_to_console(self) -> None:
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            help_instruction()
+            output: str = mock_out.getvalue()
+            self.assertTrue("Supported commands:" in output, msg=f"Output was: {output}")
+
+

--- a/test/data/test_remarkable_ssh_metadata_source.py
+++ b/test/data/test_remarkable_ssh_metadata_source.py
@@ -1,0 +1,188 @@
+"""
+Test suite for RemarkableSSHMetadataSource.
+
+This module contains unit tests for the RemarkableSSHMetadataSource
+class, including tests for:
+
+- Successful metadata retrieval and parsing from tar archives
+- Handling of SSH command failures
+- Handling of missing metadata files
+- Skipping invalid JSON metadata files
+- File size aggregation parsing
+- Error handling for size retrieval failures
+- Proper merging of metadata and file size information
+
+All interactions with the reMarkable device (SSH, subprocess calls,
+and remote command execution) are fully mocked to ensure that tests
+run deterministically and do not require a physical device.
+
+These tests were initially generated with the assistance of a Large
+Language Model (LLM) and subsequently reviewed and validated by a
+human developer.
+
+LLM used:
+- Model: ChatGPT
+- Version: GPT-5.2
+- Provider: OpenAI
+- Generation date: 2026-02-16
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+from io import BytesIO
+import tarfile
+import json
+
+from src.data.remarkable_ssh_metadata_source import RemarkableSSHMetadataSource
+
+
+class TestRemarkableSSHMetadataSource(unittest.TestCase):
+
+    def setUp(self):
+        self.source = RemarkableSSHMetadataSource()
+
+    # --------------------------------------------------
+    # Helpers
+    # --------------------------------------------------
+
+    def _create_tar_bytes(self, files: dict[str, dict]) -> bytes:
+        """
+        Create an in-memory tar archive containing *.metadata files.
+        `files` is a dict of uuid -> metadata_dict
+        """
+        tar_buffer = BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode="w:") as tar:
+            for uuid, metadata in files.items():
+                file_data = json.dumps(metadata).encode("utf-8")
+                tarinfo = tarfile.TarInfo(name=f"./{uuid}.metadata")
+                tarinfo.size = len(file_data)
+                tar.addfile(tarinfo, BytesIO(file_data))
+        return tar_buffer.getvalue()
+
+    # --------------------------------------------------
+    # load()
+    # --------------------------------------------------
+
+    @patch.object(RemarkableSSHMetadataSource, "_get_file_sizes")
+    @patch.object(RemarkableSSHMetadataSource, "_fetch_metadata")
+    def test_load_merges_sizes(self, mock_fetch, mock_sizes):
+        mock_fetch.return_value = {
+            "uuid1": {"name": "doc1"},
+            "uuid2": {"name": "doc2"},
+        }
+        mock_sizes.return_value = {
+            "uuid1": 123,
+            "uuid2": 456,
+        }
+
+        result = self.source.load()
+
+        self.assertEqual(result["uuid1"]["size"], 123)
+        self.assertEqual(result["uuid2"]["size"], 456)
+
+    # --------------------------------------------------
+    # _fetch_metadata()
+    # --------------------------------------------------
+
+    @patch("subprocess.Popen")
+    @patch.object(RemarkableSSHMetadataSource, "_get_file_sizes")
+    def test_fetch_metadata_success(self, mock_sizes, mock_popen):
+        tar_bytes = self._create_tar_bytes({
+            "uuid1": {"name": "doc1"},
+            "uuid2": {"name": "doc2"},
+        })
+
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (tar_bytes, b"")
+        mock_proc.returncode = 0
+        mock_popen.return_value = mock_proc
+
+        mock_sizes.return_value = {"uuid1": 100}
+
+        result = self.source._fetch_metadata()
+
+        self.assertIn("uuid1", result)
+        self.assertEqual(result["uuid1"]["name"], "doc1")
+        self.assertEqual(result["uuid1"]["size"], 100)
+
+        self.assertIn("uuid2", result)
+        self.assertEqual(result["uuid2"]["name"], "doc2")
+        self.assertNotIn("size", result["uuid2"])
+
+    @patch("subprocess.Popen")
+    def test_fetch_metadata_nonzero_returncode_raises(self, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (b"", b"error")
+        mock_proc.returncode = 1
+        mock_popen.return_value = mock_proc
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.source._fetch_metadata()
+
+        self.assertIn("error", str(ctx.exception))
+
+    @patch("subprocess.Popen")
+    def test_fetch_metadata_no_tar_bytes_raises(self, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (b"", b"")
+        mock_proc.returncode = 0
+        mock_popen.return_value = mock_proc
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.source._fetch_metadata()
+
+        self.assertIn("No metadata files found", str(ctx.exception))
+
+    @patch("subprocess.Popen")
+    @patch.object(RemarkableSSHMetadataSource, "_get_file_sizes")
+    def test_fetch_metadata_invalid_json_skipped(self, mock_sizes, mock_popen):
+        # Create tar with one invalid JSON file
+        tar_buffer = BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode="w:") as tar:
+            bad_data = b"{invalid json"
+            tarinfo = tarfile.TarInfo(name="./uuid1.metadata")
+            tarinfo.size = len(bad_data)
+            tar.addfile(tarinfo, BytesIO(bad_data))
+        tar_bytes = tar_buffer.getvalue()
+
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (tar_bytes, b"")
+        mock_proc.returncode = 0
+        mock_popen.return_value = mock_proc
+
+        mock_sizes.return_value = {}
+
+        result = self.source._fetch_metadata()
+
+        self.assertEqual(result, {})
+
+    # --------------------------------------------------
+    # _get_file_sizes()
+    # --------------------------------------------------
+
+    @patch("subprocess.Popen")
+    def test_get_file_sizes_success(self, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (
+            "uuid1\t100\nuuid2\t200\n",
+            ""
+        )
+        mock_proc.returncode = 0
+        mock_popen.return_value = mock_proc
+
+        result = self.source._get_file_sizes()
+
+        self.assertEqual(result["uuid1"], 100)
+        self.assertEqual(result["uuid2"], 200)
+
+    @patch("subprocess.Popen")
+    def test_get_file_sizes_nonzero_returncode_raises(self, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = ("", "error")
+        mock_proc.returncode = 1
+        mock_popen.return_value = mock_proc
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.source._get_file_sizes()
+
+        self.assertIn("error", str(ctx.exception))

--- a/test/stub_remarkable_metadata_source.py
+++ b/test/stub_remarkable_metadata_source.py
@@ -1,0 +1,15 @@
+"""
+    Module for stubbing reMarkable datasource
+"""
+from test.test_data import TEST_DATA
+
+from src.data.metadata_source import  MetadataSource
+
+
+class StubRemarkableMetadataSource(MetadataSource):
+    """
+    A class implementation of the stub
+    """
+
+    def load(self):
+        return TEST_DATA

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -1,0 +1,15 @@
+"""
+    Module for shared test data. Programmers are encouraged to update
+    the test data when needed, but it is good to keep in mind that
+    updating test data may break existing test cases.
+"""
+
+from typing import Dict
+
+TEST_DATA: Dict[str, Dict[str, str]] = {
+            "": {"type": "CollectionType", "parent": "", "visibleName": ""},
+            "a": {"type": "CollectionType", "parent": "", "visibleName": "A"},
+            "a_0": {"type": "CollectionType", "parent": "a", "visibleName": "A_0"},
+            "b": {"type": "CollectionType", "parent": "", "visibleName": "B"},
+            "b_0": {"type": "CollectionType", "parent": "b", "visibleName": "B_0"},
+        }

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -10,6 +10,7 @@ TEST_DATA: Dict[str, Dict[str, str]] = {
             "": {"type": "CollectionType", "parent": "", "visibleName": ""},
             "a": {"type": "CollectionType", "parent": "", "visibleName": "A"},
             "a_0": {"type": "CollectionType", "parent": "a", "visibleName": "A_0"},
+            "fairytale": {"type": "DocumentType", "parent": "a", "visibleName": "Fairytale.pdf", "size": "1024 kB"},
             "b": {"type": "CollectionType", "parent": "", "visibleName": "B"},
             "b_0": {"type": "CollectionType", "parent": "b", "visibleName": "B_0"},
         }

--- a/test/workspace/test_workspace_manager.py
+++ b/test/workspace/test_workspace_manager.py
@@ -1,0 +1,19 @@
+import unittest
+
+from src.workspace.workspace_manager import WorkspaceManager
+from src.workspace.remarkable_workspace import RemarkableWorkspace
+from test.stub_remarkable_metadata_source import StubRemarkableMetadataSource
+
+
+class TestWorkspaceManager(unittest.TestCase):
+
+
+    def setUp(self) -> None:
+
+        self.manager = WorkspaceManager(StubRemarkableMetadataSource())
+
+
+    def test_refresh(self) -> None:
+        ws: RemarkableWorkspace = self.manager.get()
+        ws2: RemarkableWorkspace =self.manager.refresh()
+        self.assertEqual(ws.get_data(), ws2.get_data())


### PR DESCRIPTION
## Overview

* Added unittests for common instructions and help instruction
* Stubbed metadatasource to improve testability
* Experimented whether an LLM model could successfully generate tests for `RemarkableSSHMetadataSource`. Turned out quite well I think

Test coverage is now about 95 percent. I should perhaps add to DoD that coverage should ALWAYS be above 80 percent. 