### PR TITLE
48 defect calling rm command results in error remove not implemented

### DIFF
--- a/bash-emu.py
+++ b/bash-emu.py
@@ -22,7 +22,7 @@ def main_loop() -> None:
             case "clear":
                 clear()
             case "rm":
-                rm(args)
+                rm(args, workspace_manager)
             case "ls":
                 ls(args, workspace_manager)
             case "mv":

--- a/src/com/common.py
+++ b/src/com/common.py
@@ -46,24 +46,25 @@ def mv(args: List[str], workspace_manager: WorkspaceManager) -> None:
         print("Usage (mvp): mv <filename without path> <path>")
 
 
-
-
-def rm(args: List[str]) -> None:
+def rm(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of remove command.
 
-    TODO: implement rm
-
     :param args: possible arguments
+    :param workspace_manager: manager for reMarkable workspace
     :return: None
     """
-    print(f"Remove not implemented. Called with args: {args}")
+    ws: RemarkableWorkspace = workspace_manager.get()
+
+    if len(args) == 1:
+        ws.process_remove_command(args[0])
+    else:
+        print("Usage: rm <file or path>")
+
 
 def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of the list command.
-
-    TODO: add support for args
 
     :param args: arguments for the ls command
     :param workspace_manager: manager for reMarkable workspace

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -240,14 +240,14 @@ class RemarkableWorkspace:
     def process_remove_command(self, target_pattern: str) -> None:
         """
         A remove command removes one or several entities
-        (documents and/or collections) from the reMarkable
-        device.
+        (documents and/or collections) matching the provided
+        pattern from the reMarkable device.
 
-        Handles following exceptions
+        Handles following exceptions and informs user of an error:
           - NotFoundException if source path is not found
-          - KeyError: if UUID is not found from data
+          - KeyError: if UUID is not found for data to be removed
 
-        :param target_pattern: source to remove
+        :param target_pattern: pattern for sources to be removed
         :return: None
         """
 

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -92,11 +92,11 @@ class TestCommon(unittest.TestCase):
     # -------------------------------
     # mv instruction
     # -------------------------------
-    def test_mv(self) -> None:
+    def test_mv_without_args(self) -> None:
         """
-        Move instruction is not yet implemented. This test will
-        break when the implementation occurs. A useful remainder
-        to update tests.
+        When user attempts to use mv instruction without
+        arguments, they are instructed of the usage of
+        the command
         """
         self.ws.set_current_collection("")
         with patch('sys.stdout', new=StringIO()) as mock_out:
@@ -104,17 +104,41 @@ class TestCommon(unittest.TestCase):
             output: str = mock_out.getvalue()
             self.assertTrue("Usage (mvp):" in output, msg=f"Output was: {output}")
 
-    # -------------------------------
-    # rm instruction
-    # -------------------------------
-    def test_rm(self) -> None:
+    def test_mv_with_multiple_args(self) -> None:
         """
-        Move instruction is not yet implemented. This test will
-        break when the implementation occurs. A useful remainder
-        to update tests.
+        When user attempts to use mv instruction without
+        arguments, they are instructed of the usage of
+        the command
         """
         self.ws.set_current_collection("")
         with patch('sys.stdout', new=StringIO()) as mock_out:
-            rm([])
+            mv(["-r", "foo.pdf", "bar/"], self.manager)
             output: str = mock_out.getvalue()
-            self.assertTrue("Remove not implemented." in output, msg=f"Output was: {output}")
+            self.assertTrue("Usage (mvp):" in output, msg=f"Output was: {output}")
+
+    # -------------------------------
+    # rm instruction
+    # -------------------------------
+    def test_rm_no_args(self) -> None:
+        """
+        When user attempts to use mv instruction without
+        arguments, they are instructed of the usage of
+        the command
+        """
+        self.ws.set_current_collection("")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            rm([], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("Usage: rm <file or path>" in output, msg=f"Output was: {output}")
+
+    def test_rm_too_many_args(self) -> None:
+        """
+        When user attempts to use mv instruction with
+        multiple arguments, they are instructed of the
+        usage of the command
+        """
+        self.ws.set_current_collection("")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            rm(["-rf", "/foo"], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("Usage: rm <file or path>" in output, msg=f"Output was: {output}")


### PR DESCRIPTION
## What's new

- Integrated `rm` command in top-level so that end-to-end testing may continue. 
- Added negative test cases for invalid number of arguments. 
- Created an issue for more extensive testing: #49
- Improved docstring on workspace regarding remove-command's functionality