### PR TITLE
#51 fix issue with rm not working, add initial xoctihl restart to aft…

### DIFF
--- a/src/constant.py
+++ b/src/constant.py
@@ -8,6 +8,7 @@ from typing import List
 
 SSH_CONNECT: List[str] = ["ssh", "remarkable"]
 REMOTE_PREFIX: str = "cd /home/root/.local/share/remarkable/xochitl && "
+REMOTE_UPDATE_XOCHITL = " && systemctl restart xochitl"
 ROOT_COLLECTION: str = ''
 
 COLLECTION_NOT_FOUND: str = "Collection with the given UUID was not found"

--- a/src/data/remarkable_ssh_metadata_source.py
+++ b/src/data/remarkable_ssh_metadata_source.py
@@ -13,7 +13,7 @@ from io import BytesIO
 from src.dto.metadata import Metadata
 
 from src.data.metadata_source import MetadataSource
-from src.constant import REMOTE_PREFIX, SSH_CONNECT
+from src.constant import REMOTE_PREFIX, REMOTE_UPDATE_XOCHITL, SSH_CONNECT
 from src.exception.remarkable_write_exception import RemarkableWriteException
 
 class RemarkableSSHMetadataSource(MetadataSource):
@@ -102,10 +102,9 @@ class RemarkableSSHMetadataSource(MetadataSource):
             return
 
         patterns = [f"{uuid}*" for uuid in entity_uuids]
-        quoted = " ".join(shlex.quote(p) for p in patterns)
+        removable_entities = " ".join(patterns)
 
-        cmd = REMOTE_PREFIX + f"rm -rf -- {quoted}"
-
+        cmd = REMOTE_PREFIX + f"rm -rf -- {removable_entities}" + REMOTE_UPDATE_XOCHITL
         try:
             with subprocess.Popen(
                     SSH_CONNECT + [cmd],

--- a/test/data/test_remarkable_ssh_metadata_source.py
+++ b/test/data/test_remarkable_ssh_metadata_source.py
@@ -38,7 +38,7 @@ from typing import Dict, List, Tuple
 from src.dto.entry_type_enum import EntityType
 from src.dto.metadata import Metadata
 from src.data.remarkable_ssh_metadata_source import RemarkableSSHMetadataSource
-from src.constant import SSH_CONNECT, REMOTE_PREFIX
+from src.constant import SSH_CONNECT, REMOTE_PREFIX, REMOTE_UPDATE_XOCHITL
 from src.exception.remarkable_write_exception import RemarkableWriteException
 from test.test_data import UUID_FAIRYTALE, UUID_FAIRYTALE_2
 
@@ -290,7 +290,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
         self.source.remove(uuids)
 
         # Then the remote device is called with the correct instruction
-        expected_cmd = REMOTE_PREFIX + f"rm -rf -- '{UUID_FAIRYTALE}*' '{UUID_FAIRYTALE_2}*'"
+        expected_cmd = REMOTE_PREFIX + f"rm -rf -- {UUID_FAIRYTALE}* {UUID_FAIRYTALE_2}*" + REMOTE_UPDATE_XOCHITL
 
         mock_popen.assert_called_once_with(
             SSH_CONNECT + [expected_cmd],


### PR DESCRIPTION
…er remove

It seems that for some reason the single quotes around removable entries did not work. As an initial approach this seems to work as expected.