### PR TITLE
Defect: more informative error messages with change directory

### DIFF
--- a/src/com/common.py
+++ b/src/com/common.py
@@ -7,13 +7,15 @@ import subprocess
 from typing import List
 
 from src.constant import ROOT_COLLECTION
+from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirectoryException
+from src.exception.not_a_directory_exception import NotADirectoryException
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from src.workspace.workspace_manager import WorkspaceManager
 
 
 def cd(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
-    Instruction for change directory command
+    Handles command to change directory
 
     :param args: the path to which directory should be changed to
     :param workspace_manager: manager for reMarkable workspace
@@ -28,7 +30,11 @@ def cd(args: List[str], workspace_manager: WorkspaceManager) -> None:
         print("Usage: cd OR cd <path>")
         return
     else:
-        ws.change_collection(args[0])
+        try:
+            ws.change_collection(args[0])
+        except (NoSuchFileOrDirectoryException,
+                NotADirectoryException) as e:
+            print(f"cd: {str(e)}")
 
 def mv(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """

--- a/src/constant.py
+++ b/src/constant.py
@@ -14,6 +14,8 @@ ROOT_COLLECTION: str = ''
 COLLECTION_NOT_FOUND: str = "Collection with the given UUID was not found"
 PARENT_NOT_FOUND: str = "Parent for entity not found. Parent UUID: {parent}, entity UUID: {entity}"
 INVALID_PATH: str = 'The given path does not exist'
+NO_SUCH_FILE_OR_DIRECTORY: str = 'No such file or directory'
+NOT_A_DIRECTORY: str = 'Not a directory'
 
 
 UUID_REGEX = re.compile(

--- a/src/exception/no_such_file_or_directory_exception.py
+++ b/src/exception/no_such_file_or_directory_exception.py
@@ -1,0 +1,11 @@
+"""
+    Exception to use when no metadata entry matches given path
+"""
+
+class NoSuchFileOrDirectoryException(Exception):
+    """
+        Exception indicating that no metadata file
+        with given path exists. This includes both
+        DocumentTypes (files) and CollectionTypes
+        (paths).
+    """

--- a/src/exception/not_a_directory_exception.py
+++ b/src/exception/not_a_directory_exception.py
@@ -1,0 +1,11 @@
+"""
+    Exception to raise when provided path does not
+    point to a CollectionType (directory)
+"""
+
+class NotADirectoryException(Exception):
+    """
+        Exception for handling paths that are expected to point
+        to a directory but point to another type of entity. Currently,
+        the only other type of entities are DocumentTypes (files)
+    """

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -10,10 +10,13 @@ from typing import Dict, List, Tuple, Any, Optional
 from src.data.metadata_source import MetadataSource
 from src.exception.constraint_violation_exception import ConstraintViolationException
 from src.exception.invalid_metadata_exception import InvalidMetadataException
+from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirectoryException
+from src.exception.not_a_directory_exception import NotADirectoryException
 from src.exception.not_found_exception import NotFoundException
 from src.exception.invalid_path_exception import InvalidPathException
 
-from src.constant import ROOT_COLLECTION, COLLECTION_NOT_FOUND, INVALID_PATH, PARENT_NOT_FOUND
+from src.constant import ROOT_COLLECTION, COLLECTION_NOT_FOUND, INVALID_PATH, PARENT_NOT_FOUND, NOT_A_DIRECTORY, \
+    NO_SUCH_FILE_OR_DIRECTORY
 from src.dto.metadata import Metadata
 from src.exception.remarkable_write_exception import RemarkableWriteException
 
@@ -121,20 +124,27 @@ class RemarkableWorkspace:
 
         return self._data.get(entity_uuid).get('parent')
 
-    def get_collection(self, collection: str, parent: str) -> Optional[str]:
+    def get_collection(self, file_name: str, parent: str) -> Optional[str]:
         """
         Returns the UUID of the collection with the given
         parent and a matching visible name
 
-        :param collection: a name of the collection
+        :param file_name: a name of the collection
         :param parent: UUID of the parent
         :return: an optional UUID of the collection
         """
+        has_document_type_with_given_file_name: bool = False
+                
         for k, v in self._data.items():
             if v.get('parent') != parent:
                 continue
-            if v.get('type') == 'CollectionType' and v.get('visibleName') == collection:
+            if v.get('type') == 'CollectionType' and v.get('visibleName') == file_name:
                 return k
+            if v.get('visibleName') == file_name:
+                has_document_type_with_given_file_name = True
+        if has_document_type_with_given_file_name:
+            raise NotADirectoryException(f'{file_name}: {NOT_A_DIRECTORY}')
+
         return None
 
     def get_current_path(self) -> str:
@@ -182,9 +192,14 @@ class RemarkableWorkspace:
         :param path: a string representation of a path
         :return: an optional uuid of the target collection or None if collection could not be found
         """
-        collection_pointer = self._traverse_path(path)
+
+
+        try:
+            collection_pointer = self._traverse_path(path)
+        except NotADirectoryException as e:
+            raise NotADirectoryException(f"{path}: {NOT_A_DIRECTORY}")
         if collection_pointer is None:
-            raise InvalidPathException(INVALID_PATH)
+            raise NoSuchFileOrDirectoryException(f"{path}: {NO_SUCH_FILE_OR_DIRECTORY}")
 
         self._current_collection = collection_pointer
 
@@ -389,8 +404,13 @@ class RemarkableWorkspace:
 
         See the project wiki for a comprehensive list of path changing rules.
 
+        raises:
+          - `NoSuchFileOrDirectoryException`: if no matching Collection or Document is found
+          - `NotADirectoryException`: if the only match is a DocumentType (file)
+
         :param path: a string representation of a path
-        :return: an optional uuid of the target collection or None if collection could not be found
+        :return: an optional uuid of the target collection or None if
+                    collection could not be found
         """
         directory_changes: list[str] = path.split(sep="/")
         collection_pointer = self._current_collection
@@ -398,20 +418,23 @@ class RemarkableWorkspace:
             # In absolute path traversal begins at root
             collection_pointer = ROOT_COLLECTION
 
-        for directory in directory_changes:
-            match directory:
-                # No directory change
-                case '' | '.':
-                    continue
-                # Traverse to parent
-                case '..':
-                    collection_pointer = self.get_parent(collection_pointer)
-                # Traverse to descendant
-                case _:
-                    collection_pointer = self.get_collection(directory, collection_pointer)
-            if collection_pointer is None:
-                break
 
+        try:
+            for directory in directory_changes:
+                match directory:
+                    # No directory change
+                    case '' | '.':
+                        continue
+                    # Traverse to parent
+                    case '..':
+                        collection_pointer = self.get_parent(collection_pointer)
+                    # Traverse to descendant
+                    case _:
+                        collection_pointer = self.get_collection(directory, collection_pointer)
+                if collection_pointer is None:
+                    break
+        except NotADirectoryException as e:
+            raise e
         return collection_pointer
 
     def _move_entity(self, entity_uuid: str, target_uuid: str) -> None:

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -413,7 +413,6 @@ class RemarkableWorkspace:
         See the project wiki for a comprehensive list of path changing rules.
 
         raises:
-          - `NoSuchFileOrDirectoryException`: if no matching Collection or Document is found
           - `NotADirectoryException`: if the only match is a DocumentType (file)
 
         :param path: a string representation of a path
@@ -426,23 +425,19 @@ class RemarkableWorkspace:
             # In absolute path traversal begins at root
             collection_pointer = ROOT_COLLECTION
 
-
-        try:
-            for directory in directory_changes:
-                match directory:
-                    # No directory change
-                    case '' | '.':
-                        continue
-                    # Traverse to parent
-                    case '..':
-                        collection_pointer = self.get_parent(collection_pointer)
-                    # Traverse to descendant
-                    case _:
-                        collection_pointer = self.get_collection(directory, collection_pointer)
-                if collection_pointer is None:
-                    break
-        except NotADirectoryException as e:
-            raise e
+        for directory in directory_changes:
+            match directory:
+                # No directory change
+                case '' | '.':
+                    continue
+                # Traverse to parent
+                case '..':
+                    collection_pointer = self.get_parent(collection_pointer)
+                # Traverse to descendant
+                case _:
+                    collection_pointer = self.get_collection(directory, collection_pointer)
+            if collection_pointer is None:
+                break
         return collection_pointer
 
     def _move_entity(self, entity_uuid: str, target_uuid: str) -> None:

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -129,6 +129,9 @@ class RemarkableWorkspace:
         Returns the UUID of the collection with the given
         parent and a matching visible name
 
+        raises:
+          - NotADirectoryException: if only match for a segment of a path is a DocumentType (file)
+
         :param file_name: a name of the collection
         :param parent: UUID of the parent
         :return: an optional UUID of the collection
@@ -188,6 +191,11 @@ class RemarkableWorkspace:
         Attempts to change current collection to the provided
         collection. If traversal of given path fails to locate
         a collection, InvalidPathException is raised.
+
+        raises:
+          - NotADirectoryException: instead of passing the raised exception a
+          new one is thrown to include the full path in error message
+          - NoSuchFileOrDirectoryException: no matching file or directory was found
 
         :param path: a string representation of a path
         :return: an optional uuid of the target collection or None if collection could not be found

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -47,6 +47,22 @@ class TestCommon(unittest.TestCase):
             output: str = mock_out.getvalue()
             self.assertTrue("Usage: cd OR cd <path>" in output, msg=f"Output was: {output}")
 
+    def test_cd_with_non_existing_path_informs_user_path_does_not_exist(self) -> None:
+        self.ws.set_current_collection("")
+        path: str = "/path/does/not/exist"
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            cd([path], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue(f"cd: {path}: No such file or directory" in output, msg=f"Output was: {output}")
+
+    def test_cd_to_file_informs_user_the_targer_is_not_a_directory(self) -> None:
+        self.ws.set_current_collection("")
+        path: str = "/A/Fairytale.pdf"
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            cd([path], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue(f"cd: {path}: Not a directory" in output, msg=f"Output was: {output}")
+
     # -------------------------------
     # ls instruction
     # -------------------------------

--- a/test/workspace/test_remarkable_workspace.py
+++ b/test/workspace/test_remarkable_workspace.py
@@ -5,10 +5,11 @@ from unittest.mock import patch, MagicMock
 from typing import List, Set
 
 from src.data.remarkable_ssh_metadata_source import RemarkableSSHMetadataSource
+from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirectoryException
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from src.exception.not_found_exception import NotFoundException
 from src.exception.invalid_path_exception import InvalidPathException
-from src.constant import COLLECTION_NOT_FOUND, INVALID_PATH, PARENT_NOT_FOUND
+from src.constant import COLLECTION_NOT_FOUND, INVALID_PATH, PARENT_NOT_FOUND, NO_SUCH_FILE_OR_DIRECTORY
 from test.test_data import (
     TEST_DATA,
     UUID_ROOT,
@@ -96,10 +97,10 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         assert self.ws.get_current_collection() == UUID_B0
 
     def test_change_collection_with_invalid_path_raises_error(self) -> None:
-        with self.assertRaises(InvalidPathException) as context:
+        with self.assertRaises(NoSuchFileOrDirectoryException) as context:
             self.ws.change_collection("C")
 
-        self.assertTrue(INVALID_PATH in str(context.exception))
+        self.assertTrue(NO_SUCH_FILE_OR_DIRECTORY in str(context.exception))
 
     # -----------------------
     # Get absolute path


### PR DESCRIPTION
handle both NoSuchFileException and NotADirectoryException and sow informative messages to user

As this bash-emulator tries to emulate the POSIX 2024.1 specification, it is preferred to have the behavior of cd command follow as closely the the UNIX logic. In case no such file or directory is found, we inform the user of this. If on the other hand change directory operation is tried to use on a file (DocumentType), user is informed that the target is not a directory### 