### PR TITLE
#45 add support to directory names with whitespaces

### DIFF
--- a/bash-emu.py
+++ b/bash-emu.py
@@ -1,3 +1,4 @@
+import shlex
 from src.com.common import clear, ls, mv, rm, cd
 from typing import List
 from src.com.help import help_instruction
@@ -9,7 +10,8 @@ def main_loop() -> None:
 
     while True:
         path = ws.get_current_path()
-        user_input: List[str] = input(f"remarkable~{path}$ ").split(' ')
+        # user_input: List[str] = input(f"remarkable~{path}$ ").split(' ')
+        user_input: List[str] = shlex.split(input(f"remarkable~{path}$ "))
 
         if not user_input:
             continue

--- a/bash-emu.py
+++ b/bash-emu.py
@@ -10,7 +10,6 @@ def main_loop() -> None:
 
     while True:
         path = ws.get_current_path()
-        # user_input: List[str] = input(f"remarkable~{path}$ ").split(' ')
         user_input: List[str] = shlex.split(input(f"remarkable~{path}$ "))
 
         if not user_input:

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -6,7 +6,8 @@ from src.com.common import cd, ls, mv, rm, clear
 from test.stub_remarkable_metadata_source import StubRemarkableMetadataSource
 from src.workspace.workspace_manager import WorkspaceManager
 
-from test.test_data import UUID_A
+from test.test_data import UUID_A, UUID_D_1
+
 
 class TestCommon(unittest.TestCase):
 
@@ -62,6 +63,11 @@ class TestCommon(unittest.TestCase):
             cd([path], self.manager)
             output: str = mock_out.getvalue()
             self.assertTrue(f"cd: {path}: Not a directory" in output, msg=f"Output was: {output}")
+
+    def test_cd_to_collection_with_a_whitespace_in_its_visble_name(self) -> None:
+        self.ws.set_current_collection("")
+        cd(["D 1"], self.manager)
+        self.assertTrue(self.ws.get_current_collection() == UUID_D_1)
 
     # -------------------------------
     # ls instruction

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -22,109 +22,120 @@ UUID_B = "48635ee3-f8af-4013-98f3-7f2bfc2de0e4"
 UUID_B0 = "52da29a9-96fd-47fc-bd7d-7eb825be10a3"
 UUID_A_UNDER_B = "b21ca949-1d94-4b61-afd8-59bcf7330721"
 UUID_A0_UNDER_B = "40b7fe05-1c55-4944-b434-74e3f1c48bff"
+UUID_D_1 = "0cee4351-e773-4f83-858d-0e4f52c82627"
 
 TEST_DATA: Dict[str, Dict[str, str]] = {
-            UUID_A: {
-                "type": "CollectionType",
-                "parent": "",
-                "visibleName": "A",
-                "createdTime" :1,
-                "lastModified": 0,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_A0: {
-                "type": "CollectionType",
-                "parent": UUID_A,
-                "visibleName": "A_0",
-                "createdTime" :1,
-                "lastModified": 0,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_A1: {
-                "type": "CollectionType",
-                "parent": UUID_A,
-                "visibleName": "A_1",
-                "createdTime" :1,
-                "lastModified": 0,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_FAIRYTALE: {
-                "type": "DocumentType",
-                "parent": UUID_A,
-                "visibleName": "Fairytale.pdf",
-                "size": "1024 kB",
-                "createdTime": 0,
-                "lastModified": 123456789,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_FAIRYTALE_2: {
-                "type": "DocumentType",
-                "parent": UUID_A,
-                "visibleName": "Fairytale-2.pdf",
-                "size": "1024 kB",
-                "createdTime": 0,
-                "lastModified": 123456789,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_INVALID_LAST_MODIFIED: {
-                "type": "DocumentType",
-                "parent": UUID_A,
-                "visibleName": "InvalidLastModified.pdf",
-                "size": "1024 kB",
-                "createdTime": 0,
-                "lastModified": -1,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_B: {
-                "type": "CollectionType",
-                "parent": "",
-                "visibleName": "B",
-                "createdTime": 1,
-                "lastModified": 0,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_B0: {
-                "type": "CollectionType",
-                "parent": UUID_B,
-                "visibleName": "B_0",
-                "createdTime": 1,
-                "lastModified": 0,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_A_UNDER_B: {
-                "type": "CollectionType",
-                "parent": UUID_B,
-                "visibleName": "A",
-                "createdTime": 1,
-                "lastModified": 0,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-            UUID_A0_UNDER_B: {
-                "type": "CollectionType",
-                "parent": UUID_B,
-                "visibleName": "A_0",
-                "createdTime": 1,
-                "lastModified": 0,
-                "new": False,
-                "pinned": False,
-                "source": ""
-            },
-        }
+    UUID_A: {
+        "type": "CollectionType",
+        "parent": "",
+        "visibleName": "A",
+        "createdTime" :1,
+        "lastModified": 0,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_A0: {
+        "type": "CollectionType",
+        "parent": UUID_A,
+        "visibleName": "A_0",
+        "createdTime" :1,
+        "lastModified": 0,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_A1: {
+        "type": "CollectionType",
+        "parent": UUID_A,
+        "visibleName": "A_1",
+        "createdTime" :1,
+        "lastModified": 0,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_FAIRYTALE: {
+        "type": "DocumentType",
+        "parent": UUID_A,
+        "visibleName": "Fairytale.pdf",
+        "size": "1024 kB",
+        "createdTime": 0,
+        "lastModified": 123456789,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_FAIRYTALE_2: {
+        "type": "DocumentType",
+        "parent": UUID_A,
+        "visibleName": "Fairytale-2.pdf",
+        "size": "1024 kB",
+        "createdTime": 0,
+        "lastModified": 123456789,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_INVALID_LAST_MODIFIED: {
+        "type": "DocumentType",
+        "parent": UUID_A,
+        "visibleName": "InvalidLastModified.pdf",
+        "size": "1024 kB",
+        "createdTime": 0,
+        "lastModified": -1,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_B: {
+        "type": "CollectionType",
+        "parent": "",
+        "visibleName": "B",
+        "createdTime": 1,
+        "lastModified": 0,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_B0: {
+        "type": "CollectionType",
+        "parent": UUID_B,
+        "visibleName": "B_0",
+        "createdTime": 1,
+        "lastModified": 0,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_A_UNDER_B: {
+        "type": "CollectionType",
+        "parent": UUID_B,
+        "visibleName": "A",
+        "createdTime": 1,
+        "lastModified": 0,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_A0_UNDER_B: {
+        "type": "CollectionType",
+        "parent": UUID_B,
+        "visibleName": "A_0",
+        "createdTime": 1,
+        "lastModified": 0,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+    UUID_D_1: {
+        "type": "CollectionType",
+        "parent": "",
+        "visibleName": "D 1",
+        "createdTime": 1,
+        "lastModified": 0,
+        "new": False,
+        "pinned": False,
+        "source": ""
+    },
+}

--- a/test/workspace/test_remarkable_workspace.py
+++ b/test/workspace/test_remarkable_workspace.py
@@ -16,7 +16,7 @@ from test.test_data import (
     UUID_A, UUID_A0, UUID_A1,
     UUID_B, UUID_B0, UUID_A_UNDER_B,
     UUID_FAIRYTALE, UUID_FAIRYTALE_2,
-    UUID_INVALID_LAST_MODIFIED, UUID_A0_UNDER_B)
+    UUID_INVALID_LAST_MODIFIED, UUID_A0_UNDER_B, UUID_D_1)
 
 class RemarkableWorkspaceTest(unittest.TestCase):
 
@@ -490,7 +490,8 @@ class RemarkableWorkspaceTest(unittest.TestCase):
             UUID_FAIRYTALE, UUID_FAIRYTALE_2,
             UUID_INVALID_LAST_MODIFIED,
             UUID_B, UUID_B0,
-            UUID_A_UNDER_B, UUID_A0_UNDER_B
+            UUID_A_UNDER_B, UUID_A0_UNDER_B,
+            UUID_D_1
         ]
         self.assertEqual(sorted(expected_descendants), sorted(actual_descendants))
 


### PR DESCRIPTION
The support was implemented by using shlex in the 'main module'. Now users can provide collection names with white spaces by encapulating the visibleName in quotes