### PR TITLE
#47 add information on the usage of ls

### DIFF
--- a/src/com/common.py
+++ b/src/com/common.py
@@ -80,7 +80,9 @@ def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
 
     remarkable_metadata = ws.get_data()
 
-    print(f"List called with args: {args}")
+    if args:
+        print("ls: usage: ls")
+        return
 
     result = []
     for uuid, v in remarkable_metadata.items():

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -95,6 +95,13 @@ class TestCommon(unittest.TestCase):
             self.assertTrue("1024 kB" in output, msg=f"Output was: {output}")
             self.assertTrue("/A/Fairytale.pdf" in output, msg=f"Output was: {output}")
 
+    def test_ls_with_args_informs_of_usage(self) -> None:
+        self.ws.set_current_collection(UUID_A)
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            ls(["a"], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("ls: usage: ls" in output, msg=f"Output was: {output}")
+
     # -------------------------------
     # clear instruction
     # -------------------------------


### PR DESCRIPTION
In the MvP the ls command does not yet support arguments. If user attempts to invoke ls with args, inform the user of the usage