### PR TITLE
#9 add support for providing path as an argument in ls instruction. 

### DIFF
--- a/src/com/common.py
+++ b/src/com/common.py
@@ -9,6 +9,7 @@ from typing import List
 from src.constant import ROOT_COLLECTION
 from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirectoryException
 from src.exception.not_a_directory_exception import NotADirectoryException
+from src.exception.not_found_exception import NotFoundException
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from src.workspace.workspace_manager import WorkspaceManager
 
@@ -77,12 +78,16 @@ def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
     :return: None
     """
 
-    if args:
-        print("ls: usage: ls")
+    if len(args) > 1:
+        print("ls: usage: ls or ls <path or file>")
         return
 
     ws = workspace_manager.get()
-    ws.process_ls()
+
+    try:
+        ws.process_ls(args)
+    except NotFoundException as e:
+        print(e)
 
 def clear() -> None:
     """

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -192,7 +192,27 @@ class RemarkableWorkspace:
         return (self.generate_absolute_collection_path(self._data[uuid]['parent']) +
                 "/" + self._data[uuid].get('visibleName'))
 
-    def process_ls(self) -> None:
+    def process_ls(self, args: Optional[List[str]]) -> None:
+        """
+        Processes ls command and lists files either in current
+        collection or matching the provided argument. The argument
+        is expected to be a path (collection). If argument is provided,
+        and it does not match any collection, raises NotFoundException.
+
+        :param args: optional arguments for ls
+        :return: None
+        """
+
+        collection_to_list_uuid: str
+
+        if args:
+            path: str = args.pop()
+            collection_to_list_uuid = self._traverse_path(path)
+            if collection_to_list_uuid is None:
+                raise NotFoundException("ls: no such path")
+        else:
+            collection_to_list_uuid = self.get_current_collection()
+
 
         remarkable_metadata = self.get_data()
 
@@ -201,14 +221,12 @@ class RemarkableWorkspace:
         documents: List[Tuple[str, str]] = []
 
 
-        collection_uuid = self.get_current_collection()
-
-        if not collection_uuid == ROOT_COLLECTION:
+        if not collection_to_list_uuid == ROOT_COLLECTION:
             list_result.append(f"{' '*LS_COLUMN_WIDTH}../")
         list_result.append(f"{' '*LS_COLUMN_WIDTH}./")
 
         for uuid, v in remarkable_metadata.items():
-            if v.get('parent') != self.get_current_collection():
+            if v.get('parent') != collection_to_list_uuid:
                 continue
             if v.get('type') == 'CollectionType':
                 collections.append((f"{v.get('visibleName')}/", f"{v.get('size')}"))

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -6,7 +6,7 @@ from src.com.common import cd, ls, mv, rm, clear
 from test.stub_remarkable_metadata_source import StubRemarkableMetadataSource
 from src.workspace.workspace_manager import WorkspaceManager
 
-from test.test_data import UUID_A, UUID_D_1, UUID_ROOT, UUID_A0
+from test.test_data import UUID_A, UUID_D_1, UUID_ROOT, UUID_A0, UUID_B
 
 
 class TestCommon(unittest.TestCase):
@@ -95,12 +95,35 @@ class TestCommon(unittest.TestCase):
             self.assertTrue("1024" in output, msg=f"Output was: {output}")
             self.assertTrue("Fairytale.pdf" in output, msg=f"Output was: {output}")
 
-    def test_ls_with_args_informs_of_usage(self) -> None:
+    def test_ls_with_too_many_args_informs_of_usage(self) -> None:
         self.ws.set_current_collection(UUID_A)
         with patch('sys.stdout', new=StringIO()) as mock_out:
-            ls(["a"], self.manager)
+            ls(["a", "b"], self.manager)
             output: str = mock_out.getvalue()
             self.assertTrue("ls: usage: ls" in output, msg=f"Output was: {output}")
+
+    def test_ls_with_valid_absolute_path_as_arg_lists_files_in_path(self) -> None:
+        self.ws.set_current_collection(UUID_ROOT)
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            ls(["A"], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("1024" in output, msg=f"Output was: {output}")
+            self.assertTrue("Fairytale.pdf" in output, msg=f"Output was: {output}")
+
+    def test_ls_with_valid_relative_path_as_arg_lists_files_in_path(self) -> None:
+        self.ws.set_current_collection(UUID_B)
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            ls(["../A"], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("1024" in output, msg=f"Output was: {output}")
+            self.assertTrue("Fairytale.pdf" in output, msg=f"Output was: {output}")
+
+    def test_ls_with_invalid_path_informs_user_path_not_found(self) -> None:
+        self.ws.set_current_collection(UUID_ROOT)
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            ls(["path-does-not-exist"], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("ls: no such path" in output, msg=f"Output was: {output}")
 
     def test_ls_full_output_for_root(self) -> None:
         self.ws.set_current_collection(UUID_ROOT)


### PR DESCRIPTION
The ls instruction now supports one argument: a path for which to list files. For now only providing a path is supported. In future we can add support for wildcards as well, for instance. 