### PR TITLE
71 rcp add created metadata files to remarkable

### DIFF
--- a/bash-emu.py
+++ b/bash-emu.py
@@ -1,5 +1,5 @@
 import shlex
-from src.com.common import clear, ls, mv, rm, cd
+from src.com.common import clear, ls, mv, rm, cd, rcp
 from typing import List
 from src.com.help import help_instruction
 from src.workspace.workspace_manager import default_workspace_manager as workspace_manager
@@ -28,12 +28,14 @@ def main_loop() -> None:
                 ls(args, workspace_manager)
             case "mv":
                 mv(args, workspace_manager)
+            case "rcp":
+                rcp(args, workspace_manager)
             case "help":
                 help_instruction()
             case "exit" | "x":
                 break
             case _:
-                print("Unknown command. Type help for a list of supported commands")
+                print(f"Command '{command}' not found.\nTry: help")
 
 
 if __name__ == "__main__":

--- a/src/com/common.py
+++ b/src/com/common.py
@@ -102,7 +102,8 @@ def rcp(args: List[str], workspace_manager: WorkspaceManager) -> None:
 
     if len(args) == 2:
         ws: RemarkableWorkspace = workspace_manager.get()
-        ws.process_rcp_command(args)
+        source_file, target_path = args
+        ws.process_rcp_command(source_file, target_path)
 
     else:
         print("rcp: usage: rcp <source file> <target collection>")

--- a/src/com/common.py
+++ b/src/com/common.py
@@ -13,10 +13,14 @@ from src.exception.not_found_exception import NotFoundException
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from src.workspace.workspace_manager import WorkspaceManager
 
-
 def cd(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     Handles command to change directory
+
+    Usage examples:
+      - cd foo
+      - cd ../foo
+      - cd /foo/bar
 
     :param args: the path to which directory should be changed to
     :param workspace_manager: manager for reMarkable workspace
@@ -41,13 +45,17 @@ def mv(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of move command
 
+    Usage examples:
+      - mv a.pdf /foo
+      - mv *.pdf ./bar
+
     :param args: arguments given for the instruction
     :param workspace_manager: manager for reMarkable workspace
     :return: None
     """
-    ws: RemarkableWorkspace = workspace_manager.get()
 
     if len(args) == 2:
+        ws: RemarkableWorkspace = workspace_manager.get()
         ws.process_move_command(*args)
     else:
         print("Usage (mvp): mv <filename without path> <path>")
@@ -57,21 +65,56 @@ def rm(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of remove command.
 
+    Usage examples:
+      - rm file.pdf
+      - rm /foo/bar
+      - rm *.pdf
+
     :param args: possible arguments
     :param workspace_manager: manager for reMarkable workspace
     :return: None
     """
-    ws: RemarkableWorkspace = workspace_manager.get()
 
     if len(args) == 1:
+        ws: RemarkableWorkspace = workspace_manager.get()
         ws.process_remove_command(args[0])
     else:
         print("Usage: rm <file or path>")
 
 
+def rcp(args: List[str], workspace_manager: WorkspaceManager) -> None:
+    """
+    Remote copy (rcp) copies one PDF or EPUB file from host machine
+    (user's computer running the python script) to the target machine
+    (reMarkable). Both source path and target collection must be
+    provided with absolute paths, noting that the target path must
+    be the absolute path in context of this application (i.e., the
+    file structure shown in Xoctihl GUI application), meaning that
+    root path is '/', path to directory 'foo' whose parent is root
+    is '/foo' or '/foo/' and so on.
+
+    Usage: rcp <source file> <target collection>
+
+    :param args: source file and target collection
+    :param workspace_manager: manager for reMarkable workspace
+    :return:
+    """
+
+    if len(args) == 2:
+        ws: RemarkableWorkspace = workspace_manager.get()
+        ws.process_rcp_command(args)
+
+    else:
+        print("rcp: usage: rcp <source file> <target collection>")
+
+
 def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of the list command.
+
+    Usage examples:
+      - ls
+      - ls <path>
 
     :param args: arguments for the ls command
     :param workspace_manager: manager for reMarkable workspace
@@ -82,16 +125,18 @@ def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
         print("ls: usage: ls or ls <path or file>")
         return
 
-    ws = workspace_manager.get()
-
     try:
+        ws = workspace_manager.get()
         ws.process_ls(args)
     except NotFoundException as e:
         print(e)
 
 def clear() -> None:
     """
-        Clears bash terminal
+    Clears bash terminal
+
+    Usage: clear
+
     :return: None
     """
     subprocess.run("clear", check=False)

--- a/src/constant.py
+++ b/src/constant.py
@@ -7,6 +7,8 @@ from typing import List
 
 
 SSH_CONNECT: List[str] = ["ssh", "remarkable"]
+SSH_REMOTE_HOST: str = "remarkable"
+REMARKABLE_FILE_PATH: str = "/home/root/.local/share/remarkable/xochitl"
 REMOTE_PREFIX: str = "cd /home/root/.local/share/remarkable/xochitl && "
 REMOTE_UPDATE_XOCHITL = " && systemctl restart xochitl"
 ROOT_COLLECTION: str = ''

--- a/src/data/metadata_source.py
+++ b/src/data/metadata_source.py
@@ -3,6 +3,7 @@
 """
 from typing import Dict, List, Any
 
+from src.dto.content import Content
 from src.dto.metadata import Metadata
 
 class MetadataSource:
@@ -50,4 +51,31 @@ class MetadataSource:
         :param entry_uuids: a list of UUIDs
         :return: None
         """
+        raise NotImplementedError
+
+    def remote_copy(self, source_file: str,
+                    metadata: Metadata, content: Content) -> None:
+        """
+        A public method to copy a file from host machine to
+        the target machine (reMarkable).
+
+        :param source_file: absolute path to source file to be copied
+        :param metadata: a metadata entry for the file
+        :param content: a content entry for the file
+        :return: None
+        """
+
+        raise NotImplementedError
+
+    @staticmethod
+    def restart_xochitl() -> None:
+        """
+        Restarts the xochitl service on the remote reMarkable device via SSH.
+
+        This is typically required after modifying files in the xochitl data
+        directory for changes to take effect.
+
+        :raises RemarkableOperationException: if the restart command fails
+        """
+
         raise NotImplementedError

--- a/src/data/remarkable_ssh_metadata_source.py
+++ b/src/data/remarkable_ssh_metadata_source.py
@@ -43,14 +43,6 @@ class RemarkableSSHMetadataSource(MetadataSource):
         return data
 
 
-    def refresh(self) -> None:
-        """
-        Refresh will be implemented in ticket #25
-
-        :return: None
-        """
-        raise NotImplementedError
-
     def write(self, entry_uuid: str, metadata: Metadata) -> None:
         """Write metadata file to reMarkable
 

--- a/src/data/remarkable_ssh_metadata_source.py
+++ b/src/data/remarkable_ssh_metadata_source.py
@@ -5,15 +5,23 @@
 """
 
 import subprocess
+import os
+import shutil
+import uuid
 import tarfile
 import json
-import shlex
 from typing import Dict, List, Any
 from io import BytesIO
+import tempfile
+
+from src.dto.content import Content
 from src.dto.metadata import Metadata
 
 from src.data.metadata_source import MetadataSource
-from src.constant import REMOTE_PREFIX, REMOTE_UPDATE_XOCHITL, SSH_CONNECT
+from src.constant import (
+    REMOTE_PREFIX, REMOTE_UPDATE_XOCHITL, SSH_CONNECT,
+    REMARKABLE_FILE_PATH, SSH_REMOTE_HOST)
+from src.exception.remarkable_operation_exception import RemarkableOperationException
 from src.exception.remarkable_write_exception import RemarkableWriteException
 
 class RemarkableSSHMetadataSource(MetadataSource):
@@ -127,6 +135,78 @@ class RemarkableSSHMetadataSource(MetadataSource):
                 f"OS error while removing files: {e}"
             ) from e
 
+
+    def remote_copy(self, source_file: str,
+                    metadata: Metadata, content: Content) -> None:
+        """
+        Attempts to copy a file from host machine to the
+        target machine (reMarkable).
+
+        :param source_file: absolute path to source file to be copied
+        :param metadata: a metadata entry for the file
+        :param content: a content entry for the file
+        :return: None
+        """
+
+        entry_uuid: str = str(uuid.uuid4())
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            try:
+                # copy source file with UUID filename
+                filename: str = os.path.basename(source_file)
+                uuid_filename: str = entry_uuid + os.path.splitext(filename)[1]
+
+                target_file_path = os.path.join(tmp_dir, uuid_filename)
+                shutil.copy(source_file, target_file_path)
+
+                # write metadata + content
+                metadata_file: str = os.path.join(tmp_dir, f"{entry_uuid}.metadata")
+                content_file: str = os.path.join(tmp_dir, f"{entry_uuid}.content")
+
+                with open(metadata_file, mode="w", encoding="utf-8") as file:
+                    json.dump(obj=metadata.to_dict(), fp=file, indent=4)
+
+                with open(content_file, mode="w", encoding="utf-8") as file:
+                    json.dump(obj=content.to_dict(), fp=file, indent=4)
+
+                # ---- Transfer using tar over ssh ----
+
+                tar_cmd = ["tar", "cf", "-", "-C", tmp_dir, "."]
+                ssh_cmd = ["ssh", SSH_REMOTE_HOST, f"tar xf - -C {REMARKABLE_FILE_PATH}"]
+
+                tar_proc = subprocess.Popen(tar_cmd, stdout=subprocess.PIPE)
+                ssh_proc = subprocess.Popen(ssh_cmd, stdin=tar_proc.stdout)
+
+                tar_proc.stdout.close()  # allow tar to receive SIGPIPE if ssh fails
+                ssh_proc.communicate()
+
+                if ssh_proc.returncode != 0:
+                    raise RuntimeError("SSH transfer failed")
+
+            except Exception as e:
+                raise RemarkableWriteException(f"rcp: failed to copy file: {e}")
+
+    @staticmethod
+    def restart_xochitl() -> None:
+        """
+        Restarts the xochitl service on the remote reMarkable device via SSH.
+
+        This is typically required after modifying files in the xochitl data
+        directory for changes to take effect.
+
+        :raises RemarkableOperationException: if the restart command fails
+        """
+
+        cmd = ["ssh", SSH_REMOTE_HOST, "systemctl restart xochitl"]
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            raise RemarkableOperationException(
+                f"Failed to restart xochitl:\n"
+                f"STDOUT: {result.stdout}\n"
+                f"STDERR: {result.stderr}"
+            )
 
     # ------------------------------
     # Private methods

--- a/src/exception/remarkable_operation_exception.py
+++ b/src/exception/remarkable_operation_exception.py
@@ -1,0 +1,10 @@
+"""
+    Generic exception for reMarkable operations
+"""
+
+
+class RemarkableOperationException(Exception):
+    """
+        An exception representing a failure during a non-specified
+        reMarkable operation.
+    """

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -364,7 +364,7 @@ class RemarkableWorkspace:
         except (NotFoundException, KeyError) as e:
             print(f"ERROR: {e}")
 
-    def process_rcp_command(self, args: List[str]) -> None:
+    def process_rcp_command(self, source_file: str, target_collection: str) -> None:
         """
         Remote copy (rcp) command moves one file from host machine
         to the provided collection on the target machine (reMarkable).
@@ -375,10 +375,6 @@ class RemarkableWorkspace:
         :param args: source and target
         :return: None
         """
-
-        # First: Validate source and target
-
-        source_file, target_collection = args
 
         try:
 
@@ -415,7 +411,8 @@ class RemarkableWorkspace:
             self._source.restart_xochitl()
             self._data = self._source.load()
 
-        except (NotFoundException, InvalidContentException) as e:
+        except (NotFoundException, InvalidMetadataException,
+                InvalidContentException) as e:
             print(e)
 
 

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -3,19 +3,24 @@
     reMarkable metadata content
 """
 
+import os
+import time
 import copy
 from fnmatch import fnmatchcase
 from typing import Dict, List, Tuple, Any, Optional
 
 from src.data.metadata_source import MetadataSource
+from src.dto.content import Content
+from src.dto.entry_type_enum import EntityType
 from src.exception.constraint_violation_exception import ConstraintViolationException
+from src.exception.invalid_content_exception import InvalidContentException
 from src.exception.invalid_metadata_exception import InvalidMetadataException
 from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirectoryException
 from src.exception.not_a_directory_exception import NotADirectoryException
 from src.exception.not_found_exception import NotFoundException
 from src.exception.invalid_path_exception import InvalidPathException
 
-from src.constant import ROOT_COLLECTION, COLLECTION_NOT_FOUND, INVALID_PATH, PARENT_NOT_FOUND, NOT_A_DIRECTORY, \
+from src.constant import ROOT_COLLECTION, COLLECTION_NOT_FOUND, PARENT_NOT_FOUND, NOT_A_DIRECTORY, \
     NO_SUCH_FILE_OR_DIRECTORY, LS_COLUMN_WIDTH
 from src.dto.metadata import Metadata
 from src.exception.remarkable_write_exception import RemarkableWriteException
@@ -358,6 +363,61 @@ class RemarkableWorkspace:
 
         except (NotFoundException, KeyError) as e:
             print(f"ERROR: {e}")
+
+    def process_rcp_command(self, args: List[str]) -> None:
+        """
+        Remote copy (rcp) command moves one file from host machine
+        to the provided collection on the target machine (reMarkable).
+        The source must be an absolute path to a file and the target
+        must be an absolute path to a collection.
+
+
+        :param args: source and target
+        :return: None
+        """
+
+        # First: Validate source and target
+
+        source_file, target_collection = args
+
+        try:
+
+            if not os.path.exists(source_file):
+                raise NotFoundException(f"rcp: source file {source_file} not found")
+
+            target_uuid: Optional[str] = self._traverse_path(target_collection)
+
+            if target_uuid is None:
+                raise NotFoundException(f"rcp: target path {target_collection} not found")
+
+            filename: str = os.path.basename(source_file)
+            # splitext return extension with dot. We want to remove that here.
+            file_extension: str = os.path.splitext(filename)[1][1:]
+
+            content: Content = Content.from_dict(
+                {"fileType": file_extension}
+            )
+
+            metadata: Metadata = Metadata(
+                created_time=int(time.time()),
+                last_modified=int(time.time()),
+                new=False,
+                parent=target_uuid,
+                pinned=False,
+                source="",
+                type=EntityType.DOCUMENT_TYPE,
+                visible_name=filename
+            )
+
+            self._source.remote_copy(source_file=source_file,
+                                     metadata=metadata, content=content)
+
+            self._source.restart_xochitl()
+            self._data = self._source.load()
+
+        except (NotFoundException, InvalidContentException) as e:
+            print(e)
+
 
     # ----------------------------------
     # private methods

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -2,7 +2,8 @@ import unittest
 from io import StringIO
 from unittest.mock import patch, MagicMock
 
-from src.com.common import cd, ls, mv, rm, clear
+from src.com.common import cd, ls, mv, rm, rcp, clear
+from src.workspace.remarkable_workspace import RemarkableWorkspace
 from test.stub_remarkable_metadata_source import StubRemarkableMetadataSource
 from src.workspace.workspace_manager import WorkspaceManager
 
@@ -206,6 +207,57 @@ class TestCommon(unittest.TestCase):
             output: str = mock_out.getvalue()
             self.assertTrue("Usage (mvp):" in output, msg=f"Output was: {output}")
 
+    @patch.object(RemarkableWorkspace, "process_move_command")
+    def test_mv_positive_case(self, mock_move: MagicMock) -> None:
+        source = "file.txt"
+        target = "./foo"
+        mv([source, target], self.manager)
+
+        mock_move.assert_called_once()
+
+        args, _ = mock_move.call_args
+        self.assertEqual(args[0], source)
+        self.assertEqual(args[1], target)
+
+    # -------------------------------
+    # rcp instruction
+    # -------------------------------
+    def test_rcp_without_args(self) -> None:
+        """
+        When user attempts to use rcp instruction without
+        arguments, they are instructed of the usage of
+        the command
+        """
+        self.ws.set_current_collection("")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            rcp([], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("rcp: usage:" in output, msg=f"Output was: {output}")
+
+    def test_rcp_with_too_many_args(self) -> None:
+        """
+        When user attempts to use rcp instruction with
+        too many arguments, they are instructed of the
+        usage of the command
+        """
+        self.ws.set_current_collection("")
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            rcp(["-r", "/path/to/foo.pdf", "bar/"], self.manager)
+            output: str = mock_out.getvalue()
+            self.assertTrue("rcp: usage:" in output, msg=f"Output was: {output}")
+
+    @patch.object(RemarkableWorkspace, "process_rcp_command")
+    def test_rcp_positive_case(self, mock_rcp: MagicMock) -> None:
+        source = "path/to/file.txt"
+        target = "./foo"
+        rcp([source, target], self.manager)
+
+        mock_rcp.assert_called_once()
+
+        args, _ = mock_rcp.call_args
+        self.assertEqual(args[0], source)
+        self.assertEqual(args[1], target)
+
     # -------------------------------
     # rm instruction
     # -------------------------------
@@ -232,3 +284,15 @@ class TestCommon(unittest.TestCase):
             rm(["-rf", "/foo"], self.manager)
             output: str = mock_out.getvalue()
             self.assertTrue("Usage: rm <file or path>" in output, msg=f"Output was: {output}")
+
+    @patch.object(RemarkableWorkspace, "process_remove_command")
+    def test_rm_positive_case(self, mock_remove: MagicMock) -> None:
+        file_to_remove = "file.txt"
+        rm([file_to_remove], self.manager)
+
+        mock_remove.assert_called_once()
+
+        args, _ = mock_remove.call_args
+        self.assertEqual(args[0], file_to_remove)
+
+

--- a/test/data/test_metdata_source.py
+++ b/test/data/test_metdata_source.py
@@ -1,6 +1,10 @@
 import unittest
+import time
 
 from src.data.metadata_source import MetadataSource
+from src.dto.content import Content
+from src.dto.entry_type_enum import EntityType
+from src.dto.file_type_enum import FileType
 from src.dto.metadata import Metadata
 from test.test_data import TEST_DATA, UUID_FAIRYTALE
 
@@ -30,3 +34,25 @@ class TestMetadataSource(unittest.TestCase):
     def test_remove_raises_not_implemented_error(self) -> None:
         with self.assertRaises(NotImplementedError) as ctx:
             self.source.remove([UUID_FAIRYTALE])
+
+    def test_remote_copy_raises_not_implemented_error(self) -> None:
+        metadata = Metadata(
+            created_time=int(time.time()),
+            last_modified=int(time.time()),
+            new=False,
+            parent="",
+            pinned=False,
+            source="",
+            type=EntityType.DOCUMENT_TYPE,
+            visible_name="file.pdf"
+        )
+
+        content = Content(file_type=FileType.PDF)
+
+        with self.assertRaises(NotImplementedError) as ctx:
+            self.source.remote_copy("/path/to/file.txt", metadata, content)
+
+
+    def test_restart_xochitl_raises_not_implemented_error(self) -> None:
+        with self.assertRaises(NotImplementedError) as ctx:
+            self.source.restart_xochitl()

--- a/test/data/test_remarkable_ssh_metadata_source.py
+++ b/test/data/test_remarkable_ssh_metadata_source.py
@@ -29,19 +29,25 @@ LLM used:
 
 import unittest
 import subprocess
+import time
 from unittest.mock import patch, MagicMock
 from io import BytesIO
 import tarfile
 import json
 from typing import Dict, List, Tuple
 
+from src.dto.content import Content
 from src.dto.entry_type_enum import EntityType
+from src.dto.file_type_enum import FileType
 from src.dto.metadata import Metadata
 from src.data.remarkable_ssh_metadata_source import RemarkableSSHMetadataSource
-from src.constant import SSH_CONNECT, REMOTE_PREFIX, REMOTE_UPDATE_XOCHITL
+from src.constant import SSH_CONNECT, REMOTE_PREFIX, REMOTE_UPDATE_XOCHITL, SSH_REMOTE_HOST, REMARKABLE_FILE_PATH
 from src.exception.remarkable_write_exception import RemarkableWriteException
 from test.test_data import UUID_FAIRYTALE, UUID_FAIRYTALE_2
 
+
+# System under test (SUT)
+SUT: str = "src.data.remarkable_ssh_metadata_source"
 
 class TestRemarkableSSHMetadataSource(unittest.TestCase):
 
@@ -320,3 +326,143 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
             self.source.remove([UUID_FAIRYTALE])
 
         self.assertTrue("Failed to remove files:" in str(context.exception))
+
+    # --------------------------------------------------
+    # remote copy
+    # --------------------------------------------------
+
+    @patch(f"{SUT}.subprocess.Popen")
+    def test_remote_copy_success(self, mock_popen) -> None:
+        # ---- Mock processes ----
+        mock_tar_proc = MagicMock()
+        mock_ssh_proc = MagicMock()
+
+        # tar stdout must exist (pipe to ssh)
+        mock_tar_proc.stdout = MagicMock()
+
+        # ssh behavior
+        mock_ssh_proc.communicate.return_value = (None, None)
+        mock_ssh_proc.returncode = 0
+
+        # Popen is called twice: return tar, then ssh
+        mock_popen.side_effect = [mock_tar_proc, mock_ssh_proc]
+
+
+        source_file: str = "e2e-test/test/document-0.pdf"
+
+
+        metadata: Metadata = Metadata(
+            created_time=int(time.time()),
+            last_modified=int(time.time()),
+            new=False,
+            parent="",
+            pinned=False,
+            source="",
+            type=EntityType.DOCUMENT_TYPE,
+            visible_name="file.pdf"
+        )
+
+        content: Content = Content(file_type=FileType.PDF)
+
+        with patch(f"{SUT}.shutil.copy"), \
+                patch(f"{SUT}.open", create=True), \
+                patch(f"{SUT}.json.dump"):
+
+            self.source.remote_copy(source_file=source_file, metadata=metadata, content=content)
+
+        # ---- Assertions ----
+        self.assertEqual(mock_popen.call_count, 2)
+
+        mock_ssh_proc.communicate.assert_called_once()
+        mock_tar_proc.stdout.close.assert_called_once()
+
+        calls = mock_popen.call_args_list
+
+        tar_cmd = calls[0][0][0]
+        ssh_cmd = calls[1][0][0]
+
+        self.assertEqual(tar_cmd[0], "tar")
+        self.assertEqual(ssh_cmd[0], "ssh")
+
+        _, ssh_kwargs = mock_popen.call_args_list[1]
+        self.assertEqual(ssh_kwargs["stdin"], mock_tar_proc.stdout)
+
+    @patch(f"{SUT}.subprocess.Popen")
+    def test_remote_copy_ssh_failure(self, mock_popen) -> None:
+        # ---- Mock processes ----
+        mock_tar_proc = MagicMock()
+        mock_ssh_proc = MagicMock()
+
+        mock_tar_proc.stdout = MagicMock()
+
+        # Simulate failure
+        mock_ssh_proc.communicate.return_value = (None, None)
+        mock_ssh_proc.returncode = 1  # <-- key change
+
+        mock_popen.side_effect = [mock_tar_proc, mock_ssh_proc]
+
+        source_file = "e2e-test/test/document-0.pdf"
+
+        metadata = Metadata(
+            created_time=int(time.time()),
+            last_modified=int(time.time()),
+            new=False,
+            parent="",
+            pinned=False,
+            source="",
+            type=EntityType.DOCUMENT_TYPE,
+            visible_name="file.pdf"
+        )
+
+        content = Content(file_type=FileType.PDF)
+
+        with patch(f"{SUT}.shutil.copy"), \
+                patch(f"{SUT}.open", create=True), \
+                patch(f"{SUT}.json.dump"):
+            with self.assertRaises(RemarkableWriteException):
+                self.source.remote_copy(
+                    source_file=source_file,
+                    metadata=metadata,
+                    content=content
+                )
+
+        # ---- Assertions  ----
+        self.assertEqual(mock_popen.call_count, 2)
+        mock_ssh_proc.communicate.assert_called_once()
+        mock_tar_proc.stdout.close.assert_called_once()
+
+        # Verify piping still happened before failure
+        _, ssh_kwargs = mock_popen.call_args_list[1]
+        self.assertEqual(ssh_kwargs["stdin"], mock_tar_proc.stdout)
+
+    from unittest.mock import patch, MagicMock
+
+    # --------------------------------------------------
+    # restart xochitl
+    # --------------------------------------------------
+
+    @patch("src.data.remarkable_ssh_metadata_source.subprocess.run")
+    def test_restart_xochitl_success(self, mock_run) -> None:
+        # ---- Mock subprocess result ----
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        mock_run.return_value = mock_result
+
+        # ---- Call method ----
+        RemarkableSSHMetadataSource.restart_xochitl()
+
+        # ---- Assertions ----
+        mock_run.assert_called_once()
+
+        args, kwargs = mock_run.call_args
+
+        # Verify command
+        assert args[0][0] == "ssh"
+        assert "systemctl restart xochitl" in args[0]
+
+        # Verify subprocess options
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True

--- a/test/workspace/test_remarkable_workspace.py
+++ b/test/workspace/test_remarkable_workspace.py
@@ -1,14 +1,18 @@
 import unittest
+import time
 from io import StringIO
 import copy
 from unittest.mock import patch, MagicMock
 from typing import List, Set
 
 from src.data.remarkable_ssh_metadata_source import RemarkableSSHMetadataSource
+from src.dto.metadata import Metadata
+from src.dto.content import Content
+from src.dto.file_type_enum import FileType
+from src.dto.entry_type_enum import EntityType
 from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirectoryException
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from src.exception.not_found_exception import NotFoundException
-from src.exception.invalid_path_exception import InvalidPathException
 from src.constant import COLLECTION_NOT_FOUND, INVALID_PATH, PARENT_NOT_FOUND, NO_SUCH_FILE_OR_DIRECTORY
 from test.test_data import (
     TEST_DATA,
@@ -394,6 +398,126 @@ class RemarkableWorkspaceTest(unittest.TestCase):
 
         self.assertEqual(sorted(expected_removals), sorted(passed_list),
                          msg=f"Assertion failed. Passed list: {passed_list}")
+
+    # -------------------------------------
+    # Process remote copy command
+    # -------------------------------------
+
+    from unittest.mock import patch, MagicMock
+
+    @patch("src.data.remarkable_ssh_metadata_source.os.path.exists")
+    @patch.object(RemarkableSSHMetadataSource, "load")
+    @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
+    @patch.object(RemarkableSSHMetadataSource, "remote_copy")
+    def test_process_rcp_success(
+            self,
+            mock_remote_copy: MagicMock,
+            mock_restart: MagicMock,
+            mock_load: MagicMock,
+            mock_exists: MagicMock
+    ) -> None:
+        # ---- Setup mocks ----
+        mock_exists.return_value = True
+        mock_load.return_value = ["new_data"]
+
+        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT)
+
+        source_file = "/path/to/file.pdf"
+        target_path = "/"
+
+        # ---- Execute ----
+        self.ws.process_rcp_command(source_file, target_path)
+
+        # ---- Assertions ----
+
+        # remote_copy called once
+        mock_remote_copy.assert_called_once()
+
+        # restart called
+        mock_restart.assert_called_once()
+
+        # load called and assigned
+        mock_load.assert_called_once()
+        self.assertEqual(self.ws._data, ["new_data"])
+
+        # ---- Inspect arguments passed to remote_copy ----
+        _, kwargs = mock_remote_copy.call_args
+
+        self.assertEqual(kwargs["source_file"], source_file)
+
+        metadata = kwargs["metadata"]
+        content = kwargs["content"]
+
+        # Verify metadata
+        self.assertEqual(metadata.parent, UUID_ROOT)
+        self.assertEqual(metadata.visible_name, "file.pdf")
+
+        # Verify content
+        self.assertEqual(content.file_type, "pdf")
+
+    @patch("builtins.print")
+    @patch("src.data.remarkable_ssh_metadata_source.os.path.exists")
+    @patch.object(RemarkableSSHMetadataSource, "load")
+    @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
+    @patch.object(RemarkableSSHMetadataSource, "remote_copy")
+    def test_process_rcp_source_not_found(
+            self,
+            mock_remote_copy: MagicMock,
+            mock_restart: MagicMock,
+            mock_load: MagicMock,
+            mock_exists: MagicMock,
+            mock_print: MagicMock
+    ) -> None:
+        # ---- Setup ----
+        mock_exists.return_value = False  # <-- triggers first branch
+
+        source_file = "/does/not/exist.pdf"
+        target_path = "/"
+
+        # ---- Execute ----
+        self.ws.process_rcp_command(source_file, target_path)
+
+        # ---- Assertions ----
+
+        # Nothing should be called
+        mock_remote_copy.assert_not_called()
+        mock_restart.assert_not_called()
+        mock_load.assert_not_called()
+
+        # Error was printed
+        mock_print.assert_called_once()
+
+    @patch("builtins.print")
+    @patch("src.data.remarkable_ssh_metadata_source.os.path.exists")
+    @patch.object(RemarkableSSHMetadataSource, "load")
+    @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
+    @patch.object(RemarkableSSHMetadataSource, "remote_copy")
+    def test_process_rcp_source_not_found(
+            self,
+            mock_remote_copy: MagicMock,
+            mock_restart: MagicMock,
+            mock_load: MagicMock,
+            mock_exists: MagicMock,
+            mock_print: MagicMock
+    ) -> None:
+        # ---- Setup ----
+        mock_exists.return_value = False  # <-- triggers first branch
+
+        source_file = "/does/not/exist.pdf"
+        target_path = "/"
+
+        # ---- Execute ----
+        self.ws.process_rcp_command(source_file, target_path)
+
+        # ---- Assertions ----
+
+        # Nothing should be called
+        mock_remote_copy.assert_not_called()
+        mock_restart.assert_not_called()
+        mock_load.assert_not_called()
+
+        # Error was printed
+        mock_print.assert_called_once()
 
     # -------------------------------------
     # Get wildcard matches


### PR DESCRIPTION
## Overview

This is the initial implementation of `rcp` command. During development, it came to mind that it could be beneficial to have refresh as an additional command and omit refreshing xochitl every time a write operation occurs on the device. I created another ticket for this (#78).