### PR TITLE
#78 add refresh command, add unittests, expand exit command to refresh xochitl

### DIFF
--- a/bash-emu.py
+++ b/bash-emu.py
@@ -1,5 +1,5 @@
 import shlex
-from src.com.common import clear, ls, mv, rm, cd, rcp
+from src.com.common import clear, ls, mv, rm, cd, rcp, refresh, handle_exit
 from typing import List
 from src.com.help import help_instruction
 from src.workspace.workspace_manager import default_workspace_manager as workspace_manager
@@ -32,8 +32,10 @@ def main_loop() -> None:
                 rcp(args, workspace_manager)
             case "help":
                 help_instruction()
+            case "refresh":
+                refresh()
             case "exit" | "x":
-                break
+                handle_exit()
             case _:
                 print(f"Command '{command}' not found.\nTry: help")
 

--- a/src/com/common.py
+++ b/src/com/common.py
@@ -3,6 +3,7 @@
     by reMarkable bash-emulator
 """
 
+import sys
 import subprocess
 from typing import List
 
@@ -10,6 +11,7 @@ from src.constant import ROOT_COLLECTION
 from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirectoryException
 from src.exception.not_a_directory_exception import NotADirectoryException
 from src.exception.not_found_exception import NotFoundException
+from src.exception.remarkable_operation_exception import RemarkableOperationException
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from src.workspace.workspace_manager import WorkspaceManager
 
@@ -141,3 +143,30 @@ def clear() -> None:
     :return: None
     """
     subprocess.run("clear", check=False)
+
+def refresh(workspace_manager: WorkspaceManager) -> None:
+    """
+    Uses systemctl to restart xochitl
+
+    :return: None
+    """
+    ws = workspace_manager.get()
+    try:
+        ws.restart_xochitl()
+    except RemarkableOperationException as e:
+        print(f"refresh: unexpected error occurred: {e}")
+
+
+def handle_exit(workspace_manager: WorkspaceManager) -> None:
+    """
+    Exits the application
+
+    :return: None
+    """
+    ws = workspace_manager.get()
+    try:
+        ws.restart_xochitl()
+        sys.exit(0)
+    except RemarkableOperationException as e:
+        print(e)
+        sys.exit(1)

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -23,6 +23,7 @@ from src.exception.invalid_path_exception import InvalidPathException
 from src.constant import ROOT_COLLECTION, COLLECTION_NOT_FOUND, PARENT_NOT_FOUND, NOT_A_DIRECTORY, \
     NO_SUCH_FILE_OR_DIRECTORY, LS_COLUMN_WIDTH
 from src.dto.metadata import Metadata
+from src.exception.remarkable_operation_exception import RemarkableOperationException
 from src.exception.remarkable_write_exception import RemarkableWriteException
 
 
@@ -414,6 +415,23 @@ class RemarkableWorkspace:
         except (NotFoundException, InvalidMetadataException,
                 InvalidContentException) as e:
             print(e)
+
+    def restart_xochitl(self) -> None:
+        """
+        Invokes source method handling restart
+        of xochitl GUI application
+
+        Raises:
+            may pass towards RemarkableOperationException
+            raised by the source in case subprocess fails
+
+        :return: None
+        """
+
+        try:
+            self._source.restart_xochitl()
+        except RemarkableOperationException as e:
+            raise
 
 
     # ----------------------------------

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -2,7 +2,8 @@ import unittest
 from io import StringIO
 from unittest.mock import patch, MagicMock
 
-from src.com.common import cd, ls, mv, rm, rcp, clear
+from src.com.common import cd, ls, mv, rm, rcp, clear, refresh, handle_exit
+from src.exception.remarkable_operation_exception import RemarkableOperationException
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from test.stub_remarkable_metadata_source import StubRemarkableMetadataSource
 from src.workspace.workspace_manager import WorkspaceManager
@@ -295,4 +296,50 @@ class TestCommon(unittest.TestCase):
         args, _ = mock_remove.call_args
         self.assertEqual(args[0], file_to_remove)
 
+    # -------------------------------
+    # refresh instruction
+    # -------------------------------
+    @patch.object(RemarkableWorkspace, "restart_xochitl")
+    def test_rm_positive_case(self, mock_restart_xochitl: MagicMock) -> None:
+        refresh(self.manager)
+        mock_restart_xochitl.assert_called_once()
 
+    @patch.object(RemarkableWorkspace, "restart_xochitl")
+    def test_rm_logs_exception(self, mock_restart_xochitl: MagicMock) -> None:
+        mock_restart_xochitl.side_effect = RemarkableOperationException("failure")
+
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            refresh(self.manager)
+            output = fake_out.getvalue()
+            self.assertIn("refresh: unexpected error occurred", output)
+
+        mock_restart_xochitl.assert_called_once()
+
+    # -------------------------------
+    # refresh instruction
+    # -------------------------------
+    @patch.object(RemarkableWorkspace, "restart_xochitl")
+    def test_handle_exit_success(self, mock_restart_xochitl: MagicMock) -> None:
+        mock_restart_xochitl.return_value = None
+
+        with self.assertRaises(SystemExit) as context:
+            handle_exit(self.manager)
+
+        self.assertEqual(context.exception.code, 0)
+        mock_restart_xochitl.assert_called_once()
+
+    @patch.object(RemarkableWorkspace, "restart_xochitl")
+    def test_handle_exit_failure(self, mock_restart_xochitl: MagicMock) -> None:
+        # Arrange
+        mock_restart_xochitl.side_effect = RemarkableOperationException("failure")
+
+        with patch("sys.stdout", new=StringIO()) as fake_out:
+            with self.assertRaises(SystemExit) as context:
+                handle_exit(self.manager)
+
+            self.assertEqual(context.exception.code, 1)
+
+            output = fake_out.getvalue()
+            self.assertIn("failure", output)
+
+        mock_restart_xochitl.assert_called_once()

--- a/test/workspace/test_remarkable_workspace.py
+++ b/test/workspace/test_remarkable_workspace.py
@@ -11,6 +11,7 @@ from src.dto.content import Content
 from src.dto.file_type_enum import FileType
 from src.dto.entry_type_enum import EntityType
 from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirectoryException
+from src.exception.remarkable_operation_exception import RemarkableOperationException
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from src.exception.not_found_exception import NotFoundException
 from src.constant import COLLECTION_NOT_FOUND, INVALID_PATH, PARENT_NOT_FOUND, NO_SUCH_FILE_OR_DIRECTORY
@@ -518,6 +519,24 @@ class RemarkableWorkspaceTest(unittest.TestCase):
 
         # Error was printed
         mock_print.assert_called_once()
+
+    # -------------------------------------
+    # Process refresh command
+    # -------------------------------------
+    @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
+    def test_refresh_invokes_metadata_source(self, mock_restart) -> None:
+
+        self.ws.restart_xochitl()
+        mock_restart.assert_called_once()
+
+    @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
+    def test_refresh_raises_exception_when_refresh_fails(self, mock_restart) -> None:
+        mock_restart.side_effect = RemarkableOperationException("failure")
+
+        with self.assertRaises(RemarkableOperationException) as context:
+            self.ws.restart_xochitl()
+        
+        mock_restart.assert_called_once()
 
     # -------------------------------------
     # Get wildcard matches


### PR DESCRIPTION
# Description

This PR adds the `refresh` command. Additionally `refresh` now happens when user exits the application. If user force quites with `CTRL+C`, no graceful exit is done and `refresh` is skipped. 

