### PR TITLE
#75 improve help instruction, update tests

### DIFF
--- a/bash-emu.py
+++ b/bash-emu.py
@@ -1,8 +1,10 @@
 import shlex
-from src.com.common import clear, ls, mv, rm, cd, rcp, refresh, handle_exit
 from typing import List
+
+from src.com.common import clear, ls, mv, rm, cd, rcp, refresh, handle_exit
 from src.com.help import help_instruction
 from src.workspace.workspace_manager import default_workspace_manager as workspace_manager
+
 
 def main_loop() -> None:
 
@@ -31,11 +33,11 @@ def main_loop() -> None:
             case "rcp":
                 rcp(args, workspace_manager)
             case "help":
-                help_instruction()
+                help_instruction(args)
             case "refresh":
-                refresh()
+                refresh(workspace_manager)
             case "exit" | "x":
-                handle_exit()
+                handle_exit(workspace_manager)
             case _:
                 print(f"Command '{command}' not found.\nTry: help")
 

--- a/src/com/help.py
+++ b/src/com/help.py
@@ -1,30 +1,109 @@
 """
     Method for help instruction
 """
+from typing import Dict, List
+SUPPORTED_INSTRUCTIONS: Dict[str, Dict[str, str | List[str]]] = {
 
-def help_instruction():
+
+  "clear": {
+      "description": "clears screen",
+      "usage": ["clear"],
+      "args": []
+  },
+  "ls": {
+      "description": "clears screen",
+      "args": ["path"],
+      "usage": ["ls", "ls /some/path"],
+  },
+  "mv": {
+      "description": "move entities to another collection",
+      "args": ["source or pattern", "target-path"],
+      "usage": [
+          "mv file.pdf /some/path",
+          "mv *.epub /some/path",
+          "mv * /some/path"],
+  },
+  "rm": {
+      "description": "remove entities",
+      "args": ["source or pattern"],
+      "usage": ["rm file.pdf", "rm path/","rm *.pdf", "rm *"],
+  },
+  "rcp": {
+      "description": "remote copy one PDF or EPUB file from host-machine to reMarkable",
+      "args": ["source (absolute)", "target-path (absolute)"],
+      "usage": ["rcp /path/to/host/machine/file.pdf /path/on/remarkable"],
+  },
+  "refresh": {
+      "description": "restarts xochitl GUI application",
+      "args": [],
+      "usage": ["refresh"],
+  },
+  "help": {
+      "description": "show help texts",
+      "args": ["command"],
+      "usage": ["help", "help command"],
+  },
+  "exit": {
+      "description": "exits program and restarts xochitl",
+      "args": [],
+      "usage": ["exit", "x"],
+  },
+}
+
+
+def help_instruction(args: List[str]):
     """
         Help message provides instructions on how to
         use the reMarkable bash-emulator
     """
 
-    print(
-"""
-Supported commands:
-  - clear:
-      * clear screen
-  - ls:   
-      * list files in current path
-      * supported args:
-          -a: show all files
-          -l: show files as a list
-          -h: human readable size information
-  - mv <target-path> <destination path>:   
-      * move files from target path to destination path.
-      * no supported arguments
-  - help: 
-      * show this help text
-      * no supported arguments
-  - e(x)it:
-      * exit python program
-""")
+    if len(args) > 1:
+        print("help: usage: help or help <command>")
+        return
+
+    if args:
+        command = args[0]
+        if not SUPPORTED_INSTRUCTIONS.get(command):
+            print("help: command not found: supported commands:")
+            list_commands()
+        else:
+            print_command_details(command)
+    else:
+        print_command_details("help")
+        print("")
+        list_commands()
+
+def print_command_details(command: str) -> None:
+    """
+    A helper to print out instructions for a given command
+
+    :param command: a command to print out
+    :return: None
+    """
+
+    print("")
+    command_help = SUPPORTED_INSTRUCTIONS.get(command)
+    print(f"{command}: {command_help.get("description")}")
+    if command_help.get("args"):
+        print("")
+        print("  args:")
+        for arg in command_help.get("args"):
+            print(f"    {arg}")
+    if command_help.get("usage"):
+        print("")
+        print("  usage:")
+        for usage in command_help.get("usage"):
+            print(f"    {usage}")
+    print("")
+
+
+
+def list_commands() -> None:
+    """
+    Lists commands from dictionary
+
+    :return: None
+    """
+    print("supported commands:")
+    for com in SUPPORTED_INSTRUCTIONS:
+        print(f"  {com}")

--- a/test/com/test_help.py
+++ b/test/com/test_help.py
@@ -1,6 +1,7 @@
 import unittest
 from io import StringIO
 from unittest.mock import patch
+
 from src.com.help import help_instruction
 
 
@@ -8,8 +9,33 @@ class TestHelpInstruction(unittest.TestCase):
 
     def test_help_method_prints_to_console(self) -> None:
         with patch('sys.stdout', new=StringIO()) as mock_out:
-            help_instruction()
+            help_instruction([])
             output: str = mock_out.getvalue()
-            self.assertTrue("Supported commands:" in output, msg=f"Output was: {output}")
+            self.assertTrue("supported commands:" in output, msg=f"Output was: {output}")
+
+
+    def test_help_with_command_as_arg(self) -> None:
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            help_instruction(["mv"])
+            output: str = mock_out.getvalue()
+            self.assertTrue("move entities to another collection" in output, msg=f"Output was: {output}")
+            self.assertTrue("source or pattern" in output, msg=f"Output was: {output}")
+            self.assertTrue("target-path" in output, msg=f"Output was: {output}")
+            self.assertTrue("mv file.pdf /some/path" in output, msg=f"Output was: {output}")
+            self.assertTrue("mv *.epub /some/path" in output, msg=f"Output was: {output}")
+            self.assertTrue("mv * /some/path" in output, msg=f"Output was: {output}")
+
+
+    def test_help_command_not_found(self) -> None:
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            help_instruction(["grep"])
+            output: str = mock_out.getvalue()
+            self.assertTrue("help: command not found: supported commands:" in output, msg=f"Output was: {output}")
+
+    def test_help_with_invalid_number_of_args(self) -> None:
+        with patch('sys.stdout', new=StringIO()) as mock_out:
+            help_instruction(["one", "two"])
+            output: str = mock_out.getvalue()
+            self.assertTrue("help: usage: help or help <command>" in output, msg=f"Output was: {output}")
 
 


### PR DESCRIPTION
## Description

Instead of just updating the help text string I decided to improve the functionality. Now `help` outputs instructions for `help` command and lists all supported instructions. With `help <command>` instructions for a specific command are output. This is just a draft version still, but an improvement already. 