### PR TITLE
90 rcp 20 implementation

### DIFF
--- a/src/com/common.py
+++ b/src/com/common.py
@@ -86,16 +86,20 @@ def rm(args: List[str], workspace_manager: WorkspaceManager) -> None:
 
 def rcp(args: List[str], workspace_manager: WorkspaceManager) -> None:
     """
-    Remote copy (rcp) copies one PDF or EPUB file from host machine
-    (user's computer running the python script) to the target machine
-    (reMarkable). Both source path and target collection must be
-    provided with absolute paths, noting that the target path must
-    be the absolute path in context of this application (i.e., the
-    file structure shown in Xochitl GUI application), meaning that
-    root path is '/', path to directory 'foo' whose parent is root
-    is '/foo' or '/foo/' and so on.
+    Remote copy (rcp) copies either one PDF or EPUB file from host
+    machine (user's computer running the python script) or all files
+    in provided host directory to the target machine (reMarkable).
 
-    Usage: rcp <source file> <target collection>
+    Both source path and target collection must be provided with
+    absolute paths, noting that the target path must be the absolute
+    path in context of this application (i.e., the file structure
+    shown in Xochitl GUI application), meaning that root path is '/',
+    path to directory 'foo' whose parent is root is '/foo' or '/foo/'
+    and so on.
+
+    Usages:
+      - rcp <source file> <target collection>
+      - rcp -a <source_path> <target collection>
 
     :param args: source file and target collection
     :param workspace_manager: manager for reMarkable workspace
@@ -105,8 +109,10 @@ def rcp(args: List[str], workspace_manager: WorkspaceManager) -> None:
     if len(args) == 2:
         ws: RemarkableWorkspace = workspace_manager.get()
         source_file, target_path = args
-        ws.process_rcp_command(source_file, target_path)
-
+        ws.process_rcp_command_without_flags(source_file, target_path)
+    elif len(args) > 2:
+        ws: RemarkableWorkspace = workspace_manager.get()
+        ws.process_rcp_with_flags(args)
     else:
         print("rcp: usage: rcp <source file> <target collection>")
 

--- a/src/exception/invalid_argument_exception.py
+++ b/src/exception/invalid_argument_exception.py
@@ -1,0 +1,8 @@
+"""
+    Module for invalid argument exception
+"""
+
+class InvalidArgumentException(Exception):
+    """
+        An exception raised if user provides an invalid argument
+    """

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -198,6 +198,9 @@ class RemarkableWorkspace:
         return (self.generate_absolute_collection_path(self._data[item_uuid]['parent']) +
                 "/" + self._data[item_uuid].get('visibleName'))
 
+    # -------------------------
+    # ls
+    # -------------------------
     def process_ls(self, args: Optional[List[str]]) -> None:
         """
         Processes ls command and lists files either in current
@@ -253,17 +256,9 @@ class RemarkableWorkspace:
 
         self._output_ls_result(list_result)
 
-    @staticmethod
-    def _output_ls_result(list_result: List[str]) -> None:
-        size_header = "size (kB)"
-        header_padding = " " * (LS_COLUMN_WIDTH - len(size_header))
-        name_header = "name"
-        header = f"{size_header}{header_padding}{name_header}"
-        print(header)
-        for entry in list_result:
-            print(entry)
-
-
+    # -------------------------
+    # cd
+    # -------------------------
     def change_collection(self, path: str) -> None:
         """
         Attempts to change current collection to the provided
@@ -289,6 +284,9 @@ class RemarkableWorkspace:
 
         self._current_collection = collection_pointer
 
+    # -------------------------
+    # mv
+    # -------------------------
     def process_move_command(self, source: str, path: str) -> None:
         """
         A single move instruction moves one or several entities
@@ -342,6 +340,9 @@ class RemarkableWorkspace:
                 NotFoundException) as e:
             print(f"mv: {e} ")
 
+    # -------------------------
+    # rm
+    # -------------------------
     def process_remove_command(self, target_pattern: str) -> None:
         """
         A remove command removes one or several entities
@@ -372,6 +373,9 @@ class RemarkableWorkspace:
             print(f"ERROR: {e}")
 
 
+    # -------------------------
+    # rcp
+    # -------------------------
     def process_rcp_with_flags(self, args: List[str]) -> None:
         """
         Handles rcp command with flags. Flags are meant for
@@ -403,8 +407,11 @@ class RemarkableWorkspace:
                 print(f"rcp: no pdf or epub files found in directory: {source_path}")
                 return
 
-            for source_file in files_to_copy:
+            print(f"found {len(files_to_copy)} files to copy. copying files one-by-one."
+                  f"\nDO NOT disconnect reMarkable while operation is ongoing.")
+            for idx, source_file in enumerate(files_to_copy):
                 self._copy_file_from_host_to_target(source_file, target_uuid)
+                print(f"{idx + 1}/{len(files_to_copy)}: {source_file} copied to {target_collection}")
 
             self._data = self._source.load()
 
@@ -434,7 +441,75 @@ class RemarkableWorkspace:
         except NotFoundException as e:
             print(f"rcp: {e}")
 
+    # -------------------------
+    # mkdir
+    # -------------------------
+    def process_mkdir(self, path: str) -> None:
+        """
+        Tries to create a new subdirectory to the current
+        parent.
 
+        Handles possible raised errors:
+          - InvalidPathException if path is not valid
+          - RemarkableWriteException if an error occurs while
+            communicating with the remarkable device
+
+        :param path: path to create
+        """
+
+        try:
+            self._validate_path(path)
+
+            metadata: Metadata = Metadata(
+                created_time=int(time.time()),
+                last_modified=int(time.time()),
+                new=False,
+                parent=self._current_collection,
+                pinned=False,
+                source="",
+                type=EntityType.COLLECTION_TYPE,
+                visible_name=path
+            )
+
+            # Generate a random UUID for the new entry
+            path_uuid: str = str(uuid.uuid4())
+            self._source.write_metadata(path_uuid, metadata)
+
+            self._data[path_uuid] = metadata.to_dict()
+
+        except InvalidPathException as e:
+            print(f"mkdir: {path}: {e}: hint: try help mkdir")
+        except RemarkableWriteException as e:
+            print(f"mkdir: {path}: error writing to remarkable: {e}")
+
+    def restart_xochitl(self) -> None:
+        """
+        Invokes source method handling restart
+        of xochitl GUI application
+
+        Raises:
+            may pass towards RemarkableOperationException
+            raised by the source in case subprocess fails
+
+        :return: None
+        """
+
+        self._source.restart_xochitl()
+
+
+    # ----------------------------------
+    # private methods
+    # ----------------------------------
+
+    @staticmethod
+    def _output_ls_result(list_result: List[str]) -> None:
+        size_header = "size (kB)"
+        header_padding = " " * (LS_COLUMN_WIDTH - len(size_header))
+        name_header = "name"
+        header = f"{size_header}{header_padding}{name_header}"
+        print(header)
+        for entry in list_result:
+            print(entry)
 
     def _copy_file_from_host_to_target(self, source_file: str, target_uuid: str) -> None:
         """
@@ -504,63 +579,6 @@ class RemarkableWorkspace:
                     result.append(os.path.abspath(os.path.join(dirpath, file)))
 
         return result
-
-    def process_mkdir(self, path: str) -> None:
-        """
-        Tries to create a new subdirectory to the current
-        parent.
-
-        Handles possible raised errors:
-          - InvalidPathException if path is not valid
-          - RemarkableWriteException if an error occurs while
-            communicating with the remarkable device
-
-        :param path: path to create
-        """
-
-        try:
-            self._validate_path(path)
-
-            metadata: Metadata = Metadata(
-                created_time=int(time.time()),
-                last_modified=int(time.time()),
-                new=False,
-                parent=self._current_collection,
-                pinned=False,
-                source="",
-                type=EntityType.COLLECTION_TYPE,
-                visible_name=path
-            )
-
-            # Generate a random UUID for the new entry
-            path_uuid: str = str(uuid.uuid4())
-            self._source.write_metadata(path_uuid, metadata)
-
-            self._data[path_uuid] = metadata.to_dict()
-
-        except InvalidPathException as e:
-            print(f"mkdir: {path}: {e}: hint: try help mkdir")
-        except RemarkableWriteException as e:
-            print(f"mkdir: {path}: error writing to remarkable: {e}")
-
-    def restart_xochitl(self) -> None:
-        """
-        Invokes source method handling restart
-        of xochitl GUI application
-
-        Raises:
-            may pass towards RemarkableOperationException
-            raised by the source in case subprocess fails
-
-        :return: None
-        """
-
-        self._source.restart_xochitl()
-
-
-    # ----------------------------------
-    # private methods
-    # ----------------------------------
 
     def _validate_path(self, path: str) -> None:
         """

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -411,7 +411,8 @@ class RemarkableWorkspace:
                   f"\nDO NOT disconnect reMarkable while operation is ongoing.")
             for idx, source_file in enumerate(files_to_copy):
                 self._copy_file_from_host_to_target(source_file, target_uuid)
-                print(f"{idx + 1}/{len(files_to_copy)}: {source_file} copied to {target_collection}")
+                print(f"{idx + 1}/{len(files_to_copy)}: "
+                      f"{source_file} copied to {target_collection}")
 
             self._data = self._source.load()
 

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -25,6 +25,7 @@ from src.exception.no_such_file_or_directory_exception import NoSuchFileOrDirect
 from src.exception.not_a_directory_exception import NotADirectoryException
 from src.exception.not_found_exception import NotFoundException
 from src.exception.remarkable_write_exception import RemarkableWriteException
+from src.exception.invalid_argument_exception import InvalidArgumentException
 
 
 class RemarkableWorkspace:
@@ -370,7 +371,72 @@ class RemarkableWorkspace:
         except (NotFoundException, KeyError) as e:
             print(f"ERROR: {e}")
 
-    def process_rcp_command(self, source_file: str, target_collection: str) -> None:
+
+    def process_rcp_with_flags(self, args: List[str]) -> None:
+        """
+        Handles rcp command with flags. Flags are meant for
+        copying multiple files with one command. This method
+        validates the arguments, resolves a list of
+        files to be copied and then for each file invokes
+        `process_rcp_command` separately
+
+        :param args: list of arguments
+        :return: None
+        """
+
+        try:
+            # flags MUST precede source_path and target_path
+            flags: List[str] = args[:-2]
+
+            if not self._has_only_valid_flags(flags):
+                raise InvalidArgumentException(f"invalid flags: {','.join(flags)}: hint: help rcp")
+
+            # The source and target MUST be the last two arguments
+            source_path, target_collection = args[-2:]
+
+            target_uuid: Optional[str] = self._traverse_path(target_collection)
+            self._validate_source_and_target_uuid(source_path, target_collection, target_uuid)
+
+            files_to_copy = self._find_all_pdf_and_epub_files_in_path(source_path)
+
+            if not files_to_copy:
+                print(f"rcp: no pdf or epub files found in directory: {source_path}")
+                return
+
+            for source_file in files_to_copy:
+                self._copy_file_from_host_to_target(source_file, target_uuid)
+
+            self._data = self._source.load()
+
+        except (InvalidArgumentException, NotFoundException) as e:
+            print(f"rcp: {e}")
+
+    def process_rcp_command_without_flags(self, source_file: str, target_collection: str) -> None:
+        """
+        Copies a single file defined by the user as the
+        source file to the target collection in reMarkable
+        device.
+
+        :param source_file: absolute path of a PDF or EPUB file
+        :param target_collection: absolute path of the target collection
+        :return: NOne
+        """
+
+        try:
+
+            target_uuid: Optional[str] = self._traverse_path(target_collection)
+            self._validate_source_and_target_uuid(source_file, target_collection, target_uuid)
+
+            self._copy_file_from_host_to_target(source_file, target_uuid)
+
+            self._data = self._source.load()
+
+        except NotFoundException as e:
+            print(f"rcp: {e}")
+
+
+
+    def _copy_file_from_host_to_target(self, source_file: str, target_uuid: str) -> None:
         """
         Remote copy (rcp) command moves one file from host machine
         to the provided collection on the target machine (reMarkable).
@@ -379,20 +445,11 @@ class RemarkableWorkspace:
 
 
         :param source_file: source from which to copy
-        :param target_collection: target collection
+        :param target_uuid: target collection UUID
         :return: None
         """
 
         try:
-
-            if not os.path.exists(source_file):
-                raise NotFoundException(f"rcp: source file {source_file} not found")
-
-            target_uuid: Optional[str] = self._traverse_path(target_collection)
-
-            if target_uuid is None:
-                raise NotFoundException(f"rcp: target path {target_collection} not found")
-
             filename: str = os.path.basename(source_file)
             # splitext return extension with dot. We want to remove that here.
             file_extension: str = os.path.splitext(filename)[1][1:]
@@ -415,11 +472,38 @@ class RemarkableWorkspace:
             self._source.remote_copy(source_file=source_file,
                                      metadata=metadata, content=content)
 
-            self._data = self._source.load()
 
         except (NotFoundException, InvalidMetadataException,
                 InvalidContentException) as e:
             print(e)
+
+    @staticmethod
+    def _has_only_valid_flags(flags: List[str]) -> bool:
+        # in milestone v0.2 the only supported flag is -a
+        valid_flags = ['-a']
+        for flag in flags:
+            if flag not in valid_flags:
+                return False
+        return True
+
+    @staticmethod
+    def _validate_source_and_target_uuid(source: str,
+                                         target_collection: str, target_uuid: str) -> None:
+        if not os.path.exists(source):
+            raise NotFoundException(f"rcp: source file {source} not found")
+        if target_uuid is None:
+            raise NotFoundException(f"rcp: target path {target_collection} not found")
+
+    @staticmethod
+    def _find_all_pdf_and_epub_files_in_path(path: str) -> List[str]:
+        result = []
+
+        for dirpath, _, filenames in os.walk(path):
+            for file in filenames:
+                if file.lower().endswith((".pdf", ".epub")):
+                    result.append(os.path.abspath(os.path.join(dirpath, file)))
+
+        return result
 
     def process_mkdir(self, path: str) -> None:
         """

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -577,6 +577,7 @@ class RemarkableWorkspace:
             for file in filenames:
                 if file.lower().endswith((".pdf", ".epub")):
                     result.append(os.path.abspath(os.path.join(dirpath, file)))
+            break
 
         return result
 

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -260,7 +260,7 @@ class TestCommon(unittest.TestCase):
             output: str = mock_out.getvalue()
             self.assertTrue("rcp: usage:" in output, msg=f"Output was: {output}")
 
-    def test_rcp_with_too_many_args(self) -> None:
+    def test_rcp_with_invalid_argument(self) -> None:
         """
         When user attempts to use rcp instruction with
         too many arguments, they are instructed of the
@@ -270,10 +270,10 @@ class TestCommon(unittest.TestCase):
         with patch('sys.stdout', new=StringIO()) as mock_out:
             rcp(["-r", "/path/to/foo.pdf", "bar/"], self.manager)
             output: str = mock_out.getvalue()
-            self.assertTrue("rcp: usage:" in output, msg=f"Output was: {output}")
+            self.assertTrue("rcp: invalid flags: -r" in output, msg=f"Output was: {output}")
 
-    @patch.object(RemarkableWorkspace, "process_rcp_command")
-    def test_rcp_positive_case(self, mock_rcp: MagicMock) -> None:
+    @patch.object(RemarkableWorkspace, "process_rcp_command_without_flags")
+    def test_rcp_without_flags_positive_case(self, mock_rcp: MagicMock) -> None:
         source = "path/to/file.txt"
         target = "./foo"
         rcp([source, target], self.manager)
@@ -283,6 +283,21 @@ class TestCommon(unittest.TestCase):
         args, _ = mock_rcp.call_args
         self.assertEqual(args[0], source)
         self.assertEqual(args[1], target)
+
+    @patch.object(RemarkableWorkspace, "process_rcp_with_flags")
+    def test_rcp_with_flags_positive_case(self, mock_rcp: MagicMock) -> None:
+        source = "path/to/"
+        target = "./foo"
+        flag = "-a"
+        rcp([flag, source, target], self.manager)
+
+        mock_rcp.assert_called_once()
+
+        args_tuple, _ = mock_rcp.call_args
+        list_of_args = args_tuple[0]
+        self.assertEqual(list_of_args[0], flag)
+        self.assertEqual(list_of_args[1], source)
+        self.assertEqual(list_of_args[2], target)
 
     # -------------------------------
     # rm instruction

--- a/test/workspace/test_remarkable_workspace.py
+++ b/test/workspace/test_remarkable_workspace.py
@@ -1,3 +1,4 @@
+import os
 import copy
 import unittest
 from io import StringIO
@@ -469,12 +470,10 @@ class RemarkableWorkspaceTest(unittest.TestCase):
     # Process remote copy command
     # -------------------------------------
 
-    from unittest.mock import patch, MagicMock
-
     @patch("src.data.remarkable_ssh_metadata_source.os.path.exists")
     @patch.object(RemarkableSSHMetadataSource, "load")
     @patch.object(RemarkableSSHMetadataSource, "remote_copy")
-    def test_process_rcp_success(
+    def test_process_rcp_success_without_flags(
             self,
             mock_remote_copy: MagicMock,
             mock_load: MagicMock,
@@ -490,7 +489,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         target_path = "/"
 
         # ---- Execute ----
-        self.ws.process_rcp_command(source_file, target_path)
+        self.ws.process_rcp_command_without_flags(source_file, target_path)
 
         # ---- Assertions ----
 
@@ -517,12 +516,68 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         # Verify content
         self.assertEqual(content.file_type, "pdf")
 
+    @patch("src.data.remarkable_ssh_metadata_source.os.path.exists")
+    @patch("src.data.remarkable_ssh_metadata_source.os.walk")
+    @patch.object(RemarkableSSHMetadataSource, "load")
+    @patch.object(RemarkableSSHMetadataSource, "remote_copy")
+    def test_process_rcp_success_with_valid_flags(
+            self,
+            mock_remote_copy: MagicMock,
+            mock_load: MagicMock,
+            mock_walk: MagicMock,
+            mock_exists: MagicMock,
+    ) -> None:
+        # ---- Setup mocks ----
+        mock_exists.return_value = True
+        mock_walk.return_value = [("path/to/", [], ["file1.pdf", "file2.epub"])]
+        mock_load.return_value = ["new_data"]
+
+        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT)
+
+        source_file = "/path/to/"
+        target_path = "/"
+
+        # ---- Execute ----
+        self.ws.process_rcp_with_flags(["-a", source_file, target_path])
+
+        # ---- Assertions ----
+
+        # remote_copy called twice
+        assert mock_remote_copy.call_count == 2
+
+        # load called and assigned
+        mock_load.assert_called_once()
+        self.assertEqual(self.ws._data, ["new_data"])
+
+        # ---- Inspect calls ----
+        calls = mock_remote_copy.call_args_list
+
+        expected = [
+            ("file1.pdf", "pdf"),
+            ("file2.epub", "epub"),
+        ]
+
+        for call, (filename, ext) in zip(calls, expected):
+            kwargs = call.kwargs
+
+            # source file
+            self.assertIn(filename, kwargs["source_file"])
+
+            # metadata
+            metadata = kwargs["metadata"]
+            self.assertEqual(metadata.parent, UUID_ROOT)
+            self.assertEqual(metadata.visible_name, filename)
+
+            # content
+            content = kwargs["content"]
+            self.assertEqual(content.file_type, ext)
+
     @patch("builtins.print")
     @patch("src.data.remarkable_ssh_metadata_source.os.path.exists")
     @patch.object(RemarkableSSHMetadataSource, "load")
     @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
     @patch.object(RemarkableSSHMetadataSource, "remote_copy")
-    def test_process_rcp_source_not_found(
+    def test_process_rcp_without_flags_source_not_found(
             self,
             mock_remote_copy: MagicMock,
             mock_restart: MagicMock,
@@ -537,7 +592,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         target_path = "/"
 
         # ---- Execute ----
-        self.ws.process_rcp_command(source_file, target_path)
+        self.ws.process_rcp_command_without_flags(source_file, target_path)
 
         # ---- Assertions ----
 
@@ -554,7 +609,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
     @patch.object(RemarkableSSHMetadataSource, "load")
     @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
     @patch.object(RemarkableSSHMetadataSource, "remote_copy")
-    def test_process_rcp_source_not_found(
+    def test_process_rcp_with_valid_flags_source_not_found(
             self,
             mock_remote_copy: MagicMock,
             mock_restart: MagicMock,
@@ -569,7 +624,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         target_path = "/"
 
         # ---- Execute ----
-        self.ws.process_rcp_command(source_file, target_path)
+        self.ws.process_rcp_with_flags(["-a", source_file, target_path])
 
         # ---- Assertions ----
 


### PR DESCRIPTION
## Summary of changes 

`rcp` now supports flag `-a` which can be used to copy all files with extension `pdf` or `epub` from a given path to reMarkable. Additionally identified that making the copy recursive is quite easy and opened a ticket #99 for that. Some more challenging work needs to be done regarding copying the path structure. 



## DoD checklist

Please check all items that have been addressed: 

- [x] development is based on a ticket detailing what is being done
  - [x] related ticket explains the motivation for the changes and the objectives based on which developers can reason when the issue has been fully resolved
  - [x] development was done in feature branch linked to the ticket
  - [x] all commits refer to the ticket
- [x]  new code is tested
  - [x] test coverage exceeds 80 percent 
  - [x] new functionality has been end-to-end tested
- [x]  new code has docstring or other documentation
- [x] new functionality has been documented and existing documentation has been updated
- [x] pylint score is 9.5 or higher