### PR TITLE
31 replace parameter name args with definitions from posix utility convention

### DIFF
--- a/remarkable-vfs.py
+++ b/remarkable-vfs.py
@@ -12,32 +12,32 @@ def main_loop() -> None:
 
     while True:
         path = ws.get_current_path()
-        user_input: List[str] = shlex.split(input(f"remarkable~{path}$ "))
+        cmd_line: List[str] = shlex.split(input(f"remarkable~{path}$ "))
 
-        if not user_input:
+        if not cmd_line:
             continue
 
-        command, *args = user_input
+        command, *utility_arguments = cmd_line
 
         match command:
             case "cd":
-                cd(args, workspace_manager)
+                cd(utility_arguments, workspace_manager)
             case "clear":
                 clear()
             case "rm":
-                rm(args, workspace_manager)
+                rm(utility_arguments, workspace_manager)
             case "ls":
-                ls(args, workspace_manager)
+                ls(utility_arguments, workspace_manager)
             case "mv":
-                mv(args, workspace_manager)
+                mv(utility_arguments, workspace_manager)
             case "rcp":
-                rcp(args, workspace_manager)
+                rcp(utility_arguments, workspace_manager)
             case "help":
-                help_instruction(args)
+                help_instruction(utility_arguments)
             case "refresh":
                 refresh(workspace_manager)
             case "mkdir":
-                mkdir(args, workspace_manager)
+                mkdir(utility_arguments, workspace_manager)
             case "exit" | "x":
                 handle_exit(workspace_manager)
             case _:

--- a/src/com/common.py
+++ b/src/com/common.py
@@ -15,7 +15,7 @@ from src.exception.remarkable_operation_exception import RemarkableOperationExce
 from src.workspace.remarkable_workspace import RemarkableWorkspace
 from src.workspace.workspace_manager import WorkspaceManager
 
-def cd(args: List[str], workspace_manager: WorkspaceManager) -> None:
+def cd(utility_arguments: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     Handles command to change directory
 
@@ -24,25 +24,26 @@ def cd(args: List[str], workspace_manager: WorkspaceManager) -> None:
       - cd ../foo
       - cd /foo/bar
 
-    :param args: the path to which directory should be changed to
+    :param utility_arguments: the path to which directory should be changed to
     :param workspace_manager: manager for reMarkable workspace
     """
 
     ws: RemarkableWorkspace = workspace_manager.get()
 
-    if len(args) == 0:
+    if len(utility_arguments) == 0:
         ws.set_current_collection(ROOT_COLLECTION)
-    elif len(args) > 1:
+    elif len(utility_arguments) > 1:
         print("Usage: cd OR cd <path>")
         return
     else:
         try:
-            ws.change_collection(args[0])
+            operand: str = utility_arguments[0]
+            ws.change_collection(operand)
         except (NoSuchFileOrDirectoryException,
                 NotADirectoryException) as e:
             print(f"cd: {str(e)}")
 
-def mv(args: List[str], workspace_manager: WorkspaceManager) -> None:
+def mv(utility_arguments: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of move command
 
@@ -50,18 +51,20 @@ def mv(args: List[str], workspace_manager: WorkspaceManager) -> None:
       - mv a.pdf /foo
       - mv *.pdf ./bar
 
-    :param args: arguments given for the instruction
+    :param utility_arguments: arguments given for the instruction
     :param workspace_manager: manager for reMarkable workspace
     """
 
-    if len(args) == 2:
+    if len(utility_arguments) == 2:
         ws: RemarkableWorkspace = workspace_manager.get()
-        ws.process_move_command(*args)
+        operand_source, operand_target = utility_arguments
+        ws.process_move_command(
+            operand_source=operand_source, operand_target=operand_target)
     else:
         print("Usage (mvp): mv <filename without path> <path>")
 
 
-def rm(args: List[str], workspace_manager: WorkspaceManager) -> None:
+def rm(utility_arguments: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of remove command.
 
@@ -70,18 +73,19 @@ def rm(args: List[str], workspace_manager: WorkspaceManager) -> None:
       - rm /foo/bar
       - rm *.pdf
 
-    :param args: possible arguments
+    :param utility_arguments: possible arguments
     :param workspace_manager: manager for reMarkable workspace
     """
 
-    if len(args) == 1:
+    if len(utility_arguments) == 1:
         ws: RemarkableWorkspace = workspace_manager.get()
-        ws.process_remove_command(args[0])
+        operand = utility_arguments[0]
+        ws.process_remove_command(target_pattern=operand)
     else:
         print("Usage: rm <file or path>")
 
 
-def rcp(args: List[str], workspace_manager: WorkspaceManager) -> None:
+def rcp(cmd_line: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     Remote copy (rcp) copies either one PDF or EPUB file from host
     machine (user's computer running the python script) or all files
@@ -98,22 +102,24 @@ def rcp(args: List[str], workspace_manager: WorkspaceManager) -> None:
       - rcp <source file> <target collection>
       - rcp -a <source_path> <target collection>
 
-    :param args: source file and target collection
+    :param cmd_line: source file and target collection
     :param workspace_manager: manager for reMarkable workspace
     """
 
-    if len(args) == 2:
+    if len(cmd_line) == 2:
         ws: RemarkableWorkspace = workspace_manager.get()
-        source_file, target_path = args
-        ws.process_rcp_command_without_flags(source_file, target_path)
-    elif len(args) > 2:
+        operand_source, operand_target = cmd_line
+        ws.process_rcp_command_without_flags(
+            source_file=operand_source,
+            target_collection=operand_target)
+    elif len(cmd_line) > 2:
         ws: RemarkableWorkspace = workspace_manager.get()
-        ws.process_rcp_with_flags(args)
+        ws.process_rcp_with_flags(cmd_line)
     else:
         print("rcp: usage: rcp <source file> <target collection>")
 
 
-def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
+def ls(utility_arguments: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     A light implementation of the list command.
 
@@ -121,35 +127,35 @@ def ls(args: List[str], workspace_manager: WorkspaceManager) -> None:
       - ls
       - ls <path>
 
-    :param args: arguments for the ls command
+    :param utility_arguments: arguments for the ls command
     :param workspace_manager: manager for reMarkable workspace
     """
 
-    if len(args) > 1:
+    if len(utility_arguments) > 1:
         print("ls: usage: ls or ls <path or file>")
         return
 
     try:
         ws = workspace_manager.get()
-        ws.process_ls(args)
+        ws.process_ls(utility_arguments)
     except NotFoundException as e:
         print(e)
 
-def mkdir(args: List[str], workspace_manager: WorkspaceManager) -> None:
+def mkdir(utility_arguments: List[str], workspace_manager: WorkspaceManager) -> None:
     """
     Tries to create a new directory
 
-    :param args: arguments provided for the mkdir command
+    :param utility_arguments: arguments provided for the mkdir command
     :param workspace_manager: manager for reMarkable workspace
     """
-    if len(args) != 1:
+    if len(utility_arguments) != 1:
         print("mkdir: usage: mkdir <path>")
         return
 
 
-    path = args[0]
+    operand_path = utility_arguments[0]
     ws = workspace_manager.get()
-    ws.process_mkdir(path)
+    ws.process_mkdir(operand_path)
 
 def clear() -> None:
     """

--- a/src/com/help.py
+++ b/src/com/help.py
@@ -57,8 +57,10 @@ SUPPORTED_INSTRUCTIONS: Dict[str, Dict[str, str | List[str]]] = {
   "rcp": {
       "description": "remote copy one PDF or EPUB file from host-machine to reMarkable",
       "args": [
-          "-a      flag to copy all files in source path. When using this flag, the source must be a path",
-          "source  absolute path for source (file) to copy or a path, if flag -a is used",
+          "-a      flag to copy all files in source path. When using "
+          "        this flag, the source must be a path",
+          "source  absolute path for source (file) to copy or a path,"
+          "        if flag -a is used",
           "target  absolute path to target directory"
       ],
       "usage": [

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -202,26 +202,26 @@ class RemarkableWorkspace:
     # -------------------------
     # ls
     # -------------------------
-    def process_ls(self, args: Optional[List[str]]) -> None:
+    def process_ls(self, utility_args: Optional[List[str]]) -> None:
         """
         Processes ls command and lists files either in current
         collection or matching the provided argument. The argument
         is expected to be a path (collection). If argument is provided,
         and it does not match any collection, raises NotFoundException.
 
-        :param args: optional arguments for ls
+        :param utility_args: optional utility arguments for ls
         """
 
         collection_to_list_uuid: str
 
-        if args:
-            path: str = args.pop()
-            collection_to_list_uuid = self._traverse_path(path)
+        if utility_args:
+            operand_path: str = utility_args[0]
+            collection_to_list_uuid: str | None = (
+                self._traverse_path(operand_path))
             if collection_to_list_uuid is None:
                 raise NotFoundException("ls: no such path")
         else:
             collection_to_list_uuid = self.get_current_collection()
-
 
         remarkable_metadata = self.get_data()
 
@@ -259,7 +259,7 @@ class RemarkableWorkspace:
     # -------------------------
     # cd
     # -------------------------
-    def change_collection(self, path: str) -> None:
+    def change_collection(self, operand_path: str) -> None:
         """
         Attempts to change current collection to the provided
         collection. If traversal of given path fails to locate
@@ -270,23 +270,23 @@ class RemarkableWorkspace:
           new one is thrown to include the full path in error message
           - NoSuchFileOrDirectoryException: no matching file or directory was found
 
-        :param path: a string representation of a path
+        :param operand_path: a string representation of a path operand
         """
 
 
         try:
-            collection_pointer = self._traverse_path(path)
+            collection_pointer = self._traverse_path(operand_path)
         except NotADirectoryException as e:
-            raise NotADirectoryException(f"{path}: {NOT_A_DIRECTORY}") from e
+            raise NotADirectoryException(f"{operand_path}: {NOT_A_DIRECTORY}") from e
         if collection_pointer is None:
-            raise NoSuchFileOrDirectoryException(f"{path}: {NO_SUCH_FILE_OR_DIRECTORY}")
+            raise NoSuchFileOrDirectoryException(f"{operand_path}: {NO_SUCH_FILE_OR_DIRECTORY}")
 
         self._current_collection = collection_pointer
 
     # -------------------------
     # mv
     # -------------------------
-    def process_move_command(self, source: str, path: str) -> None:
+    def process_move_command(self, operand_source: str, operand_target: str) -> None:
         """
         A single move instruction moves one or several entities
         with a common parent to the provided target path. This
@@ -301,22 +301,22 @@ class RemarkableWorkspace:
           - InvalidMetadataException if metadata validation fails
           - NotFoundException if the file to move is not found
 
-        :param source: name of the file to be moved
-        :param path: the directory of the target parent
+        :param operand_source: name of the file to be moved
+        :param operand_target: the directory of the target parent
         """
 
         try:
             # Root path can not be moved
-            if source == "":
+            if operand_source == "":
                 raise ConstraintViolationException("root path cannot be moved")
 
             # Attempt to resolve the target UUID
             # from the provided target path
-            target_uuid: Optional[str] = self._traverse_path(path)
+            target_uuid: Optional[str] = self._traverse_path(operand_target)
             if target_uuid is None:
-                raise InvalidPathException(f'{path}: {NO_SUCH_FILE_OR_DIRECTORY}')
+                raise InvalidPathException(f'{operand_target}: {NO_SUCH_FILE_OR_DIRECTORY}')
 
-            visible_name, parent_uuid = self._resolve_source_parent_and_visible_name(source)
+            visible_name, parent_uuid = self._resolve_source_parent_and_visible_name(operand_source)
 
             # attempt to move entities to the same parent
             # should result in a no-op
@@ -328,7 +328,8 @@ class RemarkableWorkspace:
                 visible_name, parent_uuid))
 
             if not entities_to_move:
-                raise NotFoundException(f"cannot move {source}: {NO_SUCH_FILE_OR_DIRECTORY}")
+                raise NotFoundException(
+                    f"cannot move {operand_source}: {NO_SUCH_FILE_OR_DIRECTORY}")
 
             for entity in entities_to_move:
                 self._move_entity(entity, target_uuid)
@@ -373,7 +374,7 @@ class RemarkableWorkspace:
     # -------------------------
     # rcp
     # -------------------------
-    def process_rcp_with_flags(self, args: List[str]) -> None:
+    def process_rcp_with_flags(self, utility_args: List[str]) -> None:
         """
         Handles rcp command with flags. Flags are meant for
         copying multiple files with one command. This method
@@ -381,18 +382,18 @@ class RemarkableWorkspace:
         files to be copied and then for each file invokes
         `process_rcp_command` separately
 
-        :param args: list of arguments
+        :param utility_args: list of utility arguments
         """
 
         try:
             # flags MUST precede source_path and target_path
-            flags: List[str] = args[:-2]
+            flags: List[str] = utility_args[:-2]
 
             if not self._has_only_valid_flags(flags):
                 raise InvalidArgumentException(f"invalid flags: {','.join(flags)}: hint: help rcp")
 
             # The source and target MUST be the last two arguments
-            source_path, target_collection = args[-2:]
+            source_path, target_collection = utility_args[-2:]
 
             target_uuid: Optional[str] = self._traverse_path(target_collection)
             self._validate_source_and_target_uuid(source_path, target_collection, target_uuid)
@@ -440,7 +441,7 @@ class RemarkableWorkspace:
     # -------------------------
     # mkdir
     # -------------------------
-    def process_mkdir(self, path: str) -> None:
+    def process_mkdir(self, operand_path: str) -> None:
         """
         Tries to create a new subdirectory to the current
         parent.
@@ -450,11 +451,11 @@ class RemarkableWorkspace:
           - RemarkableWriteException if an error occurs while
             communicating with the remarkable device
 
-        :param path: path to create
+        :param operand_path: path to create
         """
 
         try:
-            self._validate_path(path)
+            self._validate_path(operand_path)
 
             metadata: Metadata = Metadata(
                 created_time=int(time.time()),
@@ -464,7 +465,7 @@ class RemarkableWorkspace:
                 pinned=False,
                 source="",
                 type=EntityType.COLLECTION_TYPE,
-                visible_name=path
+                visible_name=operand_path
             )
 
             # Generate a random UUID for the new entry
@@ -474,9 +475,9 @@ class RemarkableWorkspace:
             self._data[path_uuid] = metadata.to_dict()
 
         except InvalidPathException as e:
-            print(f"mkdir: {path}: {e}: hint: try help mkdir")
+            print(f"mkdir: {operand_path}: {e}: hint: try help mkdir")
         except RemarkableWriteException as e:
-            print(f"mkdir: {path}: error writing to remarkable: {e}")
+            print(f"mkdir: {operand_path}: error writing to remarkable: {e}")
 
     def restart_xochitl(self) -> None:
         """

--- a/test/com/test_common.py
+++ b/test/com/test_common.py
@@ -214,9 +214,9 @@ class TestCommon(unittest.TestCase):
 
         mock_move.assert_called_once()
 
-        args, _ = mock_move.call_args
-        self.assertEqual(args[0], source)
-        self.assertEqual(args[1], target)
+        _, kwargs = mock_move.call_args
+        self.assertEqual(kwargs['operand_source'], source)
+        self.assertEqual(kwargs['operand_target'], target)
 
     # -------------------------------
     # mkdir instruction
@@ -279,9 +279,9 @@ class TestCommon(unittest.TestCase):
 
         mock_rcp.assert_called_once()
 
-        args, _ = mock_rcp.call_args
-        self.assertEqual(args[0], source)
-        self.assertEqual(args[1], target)
+        _ , kwargs = mock_rcp.call_args
+        self.assertEqual(kwargs['source_file'], source)
+        self.assertEqual(kwargs['target_collection'], target)
 
     @patch.object(RemarkableWorkspace, "process_rcp_with_flags")
     def test_rcp_with_flags_positive_case(self, mock_rcp: MagicMock) -> None:
@@ -332,8 +332,8 @@ class TestCommon(unittest.TestCase):
 
         mock_remove.assert_called_once()
 
-        args, _ = mock_remove.call_args
-        self.assertEqual(args[0], file_to_remove)
+        _, kwargs = mock_remove.call_args
+        self.assertEqual(kwargs['target_pattern'], file_to_remove)
 
 
 


### PR DESCRIPTION
## Summary of changes 

Adjusted the naming convention in main file, common.py and remarkable_workspace.py. The idea is to follow more closely the naming convention of POSIX specification. It's still not one-to-one, but it's closer. 

## DoD checklist

Please check all items that have been addressed: 

- [x] development is based on a ticket detailing what is being done
  - [x] related ticket explains the motivation for the changes and the objectives based on which developers can reason when the issue has been fully resolved
  - [x] development was done in feature branch linked to the ticket
  - [x] all commits refer to the ticket
- [x]  new code is tested
  - [x] test coverage exceeds 80 percent 
  - [x] new functionality has been end-to-end tested
- [x]  new code has docstring or other documentation
- [x] new functionality has been documented and existing documentation has been updated
- [x] pylint score is 9.5 or higher