### PR TITLE
34 improve error messages and add logging for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,36 @@ pip install -r requirements-dev.txt
 > Review `requirements-dev.txt` before installing.
 
 
+### Developer tools: Logging
+
+The purpose of logging is to support in development process and its focus should always remain on that. No information relevant to end user should ever be passed in a log message. 
+
+Logging with default level
+```bash
+$ python3 remarkable-vfs.py --log 
+```
+
+Logging with user specified level
+```bash
+$ python3 remarkable-vfs.py --log  --log-level DEBUG
+```
+
+More information on supported arguments and available log levels: 
+```bash
+$ python3 remarkable-vfs.py --help
+```
+
+
 ### Linting
 
 ```bash
 pylint src/
+```
+
+### Type checking
+
+```bash
+mypy .
 ```
 
 ### Testing

--- a/e2e-test/test-reports/report-template.md
+++ b/e2e-test/test-reports/report-template.md
@@ -224,3 +224,16 @@ Used test material: content of directory `test/`
 * [ ] TC1: Refresh restarts xochitl.service
   1. input: `refresh`
   2. expected outcome: xochitl.service restarts. Verify this from the GUI application on reMarkable and on systemctl (e.g. `systemctl status xochitl.service`). 
+
+## Test Suite: developer tool: logging
+
+* [ ] TC1: Logging with default level
+  1. Launch the application with `python3 remarkable-vfs.py --log` 
+  2. Confirm that the default log level is used (INFO). 
+* [ ] TC2: Specifying the log level
+  1. Launch the application with `python3 remarkable-vfs.py --log  --log-level DEBUG`
+  2. Confirm that the log level DEBUG is used. 
+  3. Also try this with other supported log levels.
+* [ ] TC3: No logging 
+  1. Launch the application with `python3 remarkable-vfs.py`
+  2. Confirm that logging is disabled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.mypy]
+strict = true

--- a/remarkable-vfs.py
+++ b/remarkable-vfs.py
@@ -8,6 +8,7 @@ from src.com.common import clear, ls, mv, rm, cd, rcp, mkdir, rename, refresh, h
 from src.com.help import help_instruction
 from src.workspace.workspace_manager import default_workspace_manager as workspace_manager
 
+logger = logging.getLogger(__name__)
 
 def main_loop() -> None:
 
@@ -79,10 +80,13 @@ def init_logging(args: Namespace) -> None:
             level=level,
             format="%(levelname)s:%(name)s: %(message)s",
         )
+        logger.info(f"Logging enabled. Using log level {args.log_level}")
 
 
-def main() -> None:
+if __name__ == "__main__":
     parser = init_argparse()
     init_logging(parser.parse_args())
+
+    logger.info("Starting Remarkable VirtualFilesSystem main loop")
 
     main_loop()

--- a/remarkable-vfs.py
+++ b/remarkable-vfs.py
@@ -1,4 +1,7 @@
 import shlex
+import argparse
+import logging
+from argparse import ArgumentParser, Namespace
 from typing import List
 
 from src.com.common import clear, ls, mv, rm, cd, rcp, mkdir, rename, refresh, handle_exit
@@ -46,5 +49,40 @@ def main_loop() -> None:
                 print(f"Command '{command}' not found.\nTry: help")
 
 
-if __name__ == "__main__":
+def init_argparse() -> ArgumentParser:
+    """
+    Initializes argument parser
+
+    :return: initialized argument parser
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--log", action="store_true")
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARN", "ERROR"],
+        default="INFO",
+    )
+    return parser
+
+
+def init_logging(args: Namespace) -> None:
+    if args.log:
+        level = {
+            "DEBUG": logging.DEBUG,
+            "INFO": logging.INFO,
+            "WARN": logging.WARNING,
+            "ERROR": logging.ERROR,
+        }[args.log_level]
+
+        logging.basicConfig(
+            level=level,
+            format="%(levelname)s:%(name)s: %(message)s",
+        )
+
+
+def main() -> None:
+    parser = init_argparse()
+    init_logging(parser.parse_args())
+
     main_loop()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,15 @@
+ast_serialize==0.8.0
 astroid==4.0.4
 coverage==7.13.4
 dill==0.4.1
 iniconfig==2.3.0
 isort==7.0.0
+librt==0.15.0
 mccabe==0.7.0
+mypy==2.3.0
+mypy_extensions==1.1.0
 packaging==26.0
+pathspec==1.1.1
 platformdirs==4.9.1
 pluggy==1.6.0
 pyenchant==3.3.0
@@ -13,3 +18,4 @@ pylint==4.0.4
 pytest==9.0.3
 pytest-cov==7.1.0
 tomlkit==0.14.0
+typing_extensions==4.16.0

--- a/src/com/common.py
+++ b/src/com/common.py
@@ -108,14 +108,14 @@ def rcp(cmd_line: List[str], workspace_manager: WorkspaceManager) -> None:
     :param workspace_manager: manager for reMarkable workspace
     """
 
+    ws: RemarkableWorkspace = workspace_manager.get()
+
     if len(cmd_line) == 2:
-        ws: RemarkableWorkspace = workspace_manager.get()
         operand_source, operand_target = cmd_line
         ws.process_rcp_command_without_options(
             source_file=operand_source,
             target_collection=operand_target)
     elif len(cmd_line) > 2:
-        ws: RemarkableWorkspace = workspace_manager.get()
         ws.process_rcp_with_options(cmd_line)
     else:
         print("rcp: usage: rcp <source file> <target collection>")

--- a/src/com/help.py
+++ b/src/com/help.py
@@ -111,7 +111,7 @@ SUPPORTED_INSTRUCTIONS: Dict[str, Dict[str, str | List[str]]] = {
 }
 
 
-def help_instruction(args: List[str]):
+def help_instruction(args: List[str]) -> None:
     """
         Help message provides instructions on how to
         use the reMarkable bash-emulator
@@ -143,22 +143,22 @@ def print_command_details(command: str) -> None:
     """
 
     print("")
-    command_help = SUPPORTED_INSTRUCTIONS.get(command)
-    print(f"{command}: {command_help.get("description")}")
+    command_help = SUPPORTED_INSTRUCTIONS[command]
+    print(f"{command}: {command_help["description"]}")
     if command_help.get("args"):
         print("")
         print("  args:")
-        for arg in command_help.get("args"):
+        for arg in command_help["args"]:
             print(f"    {arg}")
     if command_help.get("usage"):
         print("")
         print("  usage:")
-        for usage in command_help.get("usage"):
+        for usage in command_help["usage"]:
             print(f"    {usage}")
     if command_help.get("info"):
         print("")
         print("  additional information:")
-        for info in command_help.get("info"):
+        for info in command_help["info"]:
             print(f"    {info}")
     print("")
 

--- a/src/workspace/remarkable_workspace.py
+++ b/src/workspace/remarkable_workspace.py
@@ -79,6 +79,7 @@ class RemarkableWorkspace:
 
         Raises:
           - NotFoundError if the entity is not found
+          - InvalidMetadataError if visibleName is not an instance of str
 
         :param entity_uuid: UUID for a Document or Collection type
         :return: visible name of the entity
@@ -92,7 +93,12 @@ class RemarkableWorkspace:
         if not data:
             raise NotFoundError(f"Metadata not found for {entity_uuid}")
 
-        return data.get('visibleName')
+        visible_name = data['visibleName']
+
+        if not isinstance(visible_name, str):
+            raise InvalidMetadataError(f"invalid visible_name: {visible_name}")
+
+        return visible_name
 
 
 
@@ -129,6 +135,7 @@ class RemarkableWorkspace:
         """
         raises:
           - NotFoundError: if parent is not found
+          - InvalidMetadataError if field parent is not instance of str
 
         :param entity_uuid: optional uuid of an entity for which parent should be given
                         if no parameter is given, parent of current collection is returned
@@ -136,16 +143,25 @@ class RemarkableWorkspace:
                     parent is root or the current collection is root, an empty string is returned
         """
 
-        if entity_uuid is None:
+        if entity_uuid is None or not isinstance(entity_uuid, str):
             entity_uuid = self._current_collection
 
-        if entity_uuid == ROOT_COLLECTION or self._data.get(entity_uuid) == ROOT_COLLECTION:
+        entity_uuid_str = str(entity_uuid)
+
+        if entity_uuid_str == ROOT_COLLECTION:
             return ROOT_COLLECTION
 
-        if not self._data.get(entity_uuid):
+        if not self.get_data().get(entity_uuid_str):
             raise NotFoundError(COLLECTION_NOT_FOUND)
 
-        return self._data.get(entity_uuid).get('parent')
+        candidate: Dict[str, Any] = self.get_data()[entity_uuid_str]
+
+        parent = candidate['parent']
+
+        if not isinstance(parent, str):
+            raise InvalidMetadataError(f'parent was not an instance of str: {parent}')
+
+        return parent
 
     def get_collection(self, file_name: str, parent: str) -> Optional[str]:
         """
@@ -198,15 +214,24 @@ class RemarkableWorkspace:
         if not self._data.get(item_uuid):
             return './<NA>'
 
-        # print(f"data for {uuid}: {remarkable_metadata.get(uuid)}")
-        if self._data[item_uuid].get('parent') == '':
-            return "/" + self._data[item_uuid]['visibleName']
+        entity = self.get_data()[item_uuid]
+        parent = entity.get('parent')
+        visible_name = entity.get('visibleName')
+
+        if not isinstance(parent, str):
+            raise InvalidMetadataError('parent was not an instance of str')
+
+        if not isinstance(visible_name, str):
+            raise InvalidMetadataError('visibleName was not an instance of str')
+
+
+        if parent == '':
+            return "/" + visible_name
 
         if self._data[item_uuid].get('parent') == 'trash':
-            return '/trash/' + self._data[item_uuid].get('visibleName')
+            return '/trash/' + visible_name
 
-        return (self.generate_absolute_collection_path(self._data[item_uuid]['parent']) +
-                "/" + self._data[item_uuid].get('visibleName'))
+        return self.generate_absolute_collection_path(parent) + "/" + visible_name
 
     # -------------------------
     # ls
@@ -220,8 +245,6 @@ class RemarkableWorkspace:
 
         :param utility_args: optional utility arguments for ls
         """
-
-        collection_to_list_uuid: str
 
         if utility_args:
             operand_path: str = utility_args[0]
@@ -255,13 +278,13 @@ class RemarkableWorkspace:
 
         for t in sorted(collections, key=lambda x: x[0].lower()):
             name, size = t
-            padding: str = ' '*(LS_COLUMN_WIDTH - len(size))
-            list_result.append(f"{size}{padding}{name}")
+            padding_col: str = ' '*(LS_COLUMN_WIDTH - len(size))
+            list_result.append(f"{size}{padding_col}{name}")
 
         for t in sorted(documents, key=lambda x: x[0].lower()):
             name, size = t
-            padding: str = ' ' * (LS_COLUMN_WIDTH - len(size))
-            list_result.append(f"{size}{padding}{name}")
+            padding_doc: str = ' ' * (LS_COLUMN_WIDTH - len(size))
+            list_result.append(f"{size}{padding_doc}{name}")
 
         self._output_ls_result(list_result)
 
@@ -406,7 +429,8 @@ class RemarkableWorkspace:
             source_path, target_collection = utility_args[-2:]
 
             target_uuid: Optional[str] = self._traverse_path(target_collection)
-            self._validate_source_and_target_uuid(source_path, target_collection, target_uuid)
+            validated_target_uuid = self._validate_source_and_target_uuid(
+                source_path, target_collection, target_uuid)
 
             recurse = options[0] == "-r"
 
@@ -419,7 +443,7 @@ class RemarkableWorkspace:
 
             files_and_parents: List[Tuple[str, str]] = (
                 self._generate_target_path_uuid_and_source_file_pairs(
-                source_path, files_to_copy, target_uuid))
+                source_path, files_to_copy, validated_target_uuid))
 
             print(f"found {len(files_to_copy)} files to copy. copying files one-by-one."
                   f"\nDO NOT disconnect reMarkable while operation is ongoing.")
@@ -447,9 +471,10 @@ class RemarkableWorkspace:
         try:
 
             target_uuid: Optional[str] = self._traverse_path(target_collection)
-            self._validate_source_and_target_uuid(source_file, target_collection, target_uuid)
+            validated_target_uuid = self._validate_source_and_target_uuid(
+                source_file, target_collection, target_uuid)
 
-            self._copy_file_from_host_to_target(source_file, target_uuid)
+            self._copy_file_from_host_to_target(source_file, validated_target_uuid)
 
             self._data = self._source.load()
 
@@ -511,7 +536,7 @@ class RemarkableWorkspace:
 
             self._validate_visible_name(parent_uuid, entity_uuid, new_visible_name)
 
-            new_metadata_entry: Dict[str, Any] = copy.deepcopy(self._data.get(entity_uuid))
+            new_metadata_entry: Dict[str, Any] = copy.deepcopy(self._data[entity_uuid])
             new_metadata_entry['visibleName'] = new_visible_name
 
             # Create a Metadata DTO for given UUID
@@ -654,11 +679,13 @@ class RemarkableWorkspace:
     @staticmethod
     def _validate_source_and_target_uuid(source: str,
                                          target_collection: str,
-                                         target_uuid: Optional[str]) -> None:
+                                         target_uuid: Optional[str]) -> str:
         if not os.path.exists(source):
             raise NotFoundError(f"rcp: source file {source} not found")
         if target_uuid is None:
             raise NotFoundError(f"rcp: target path {target_collection} not found")
+
+        return target_uuid
 
     @staticmethod
     def _find_all_pdf_and_epub_files_in_path(path: str, recurse: bool) -> List[str]:
@@ -734,10 +761,10 @@ class RemarkableWorkspace:
                 if entry['visibleName'] == child_visible_name and entry['parent'] == parent:
                     return entry_uuid
 
-        entry_uuid: str =  self._create_collection_metadata_and_invoke_write(
+        new_entry_uuid: str =  self._create_collection_metadata_and_invoke_write(
             parent, child_visible_name)
 
-        return entry_uuid
+        return new_entry_uuid
 
     def _validate_visible_name(self, parent_uuid: str,
                                entry_uuid: str,
@@ -800,7 +827,8 @@ class RemarkableWorkspace:
             raise InvalidPathError("path contains invalid characters")
 
 
-    def _parent_has_child_path_with_given_name(self, parent_uuid, child_visible_name) -> bool:
+    def _parent_has_child_path_with_given_name(
+            self, parent_uuid: str, child_visible_name: str) -> bool:
         """
         Verifies, whether the provided parent UUID has a child collection
         with the given visibleName.
@@ -893,9 +921,9 @@ class RemarkableWorkspace:
             entities_to_write.extend(
                 self._get_matches_for_wildcard(parent_uuid, visible_name)
             )
-            for entity_uuid in entities_to_write:
-                if self._entry_is_a_collection(entity_uuid):
-                    entities_to_write.extend(self._get_descendant_uuids(entity_uuid))
+            for entry_uuid in entities_to_write:
+                if self._entry_is_a_collection(entry_uuid):
+                    entities_to_write.extend(self._get_descendant_uuids(entry_uuid))
         else:
             # Get the metadata and UUID of the file in question
             entity_uuid: str = self._get_uuid_with_visible_name_and_parent(
@@ -949,7 +977,8 @@ class RemarkableWorkspace:
                     collection could not be found
         """
         directory_changes: list[str] = path.split(sep="/")
-        collection_pointer = self._current_collection
+        collection_pointer: Optional[str] = self._current_collection
+
         if directory_changes[0] == '':
             # In absolute path traversal begins at root
             collection_pointer = ROOT_COLLECTION
@@ -964,6 +993,8 @@ class RemarkableWorkspace:
                     collection_pointer = self.get_parent(collection_pointer)
                 # Traverse to descendant
                 case _:
+                    if not isinstance(collection_pointer, str):
+                        break
                     collection_pointer = self.get_collection(directory, collection_pointer)
             if collection_pointer is None:
                 break
@@ -989,7 +1020,7 @@ class RemarkableWorkspace:
                     f"destination must not contain a child with the same name: "
                     f"{self.get_visible_name_for_uuid(entity_uuid)}")
 
-            new_metadata_entry: Dict[str, Any] = copy.deepcopy(self._data.get(entity_uuid))
+            new_metadata_entry: Dict[str, Any] = copy.deepcopy(self._data[entity_uuid])
             new_metadata_entry['parent'] = target_uuid
 
             # Create a Metadata DTO for given UUID
@@ -1049,7 +1080,7 @@ class RemarkableWorkspace:
 
         for k, v in self.get_data().items():
             has_matching_visible_name: bool = self._visible_name_matches_wildcard(
-                wildcard, v.get('visibleName'))
+                wildcard, v['visibleName'])
             if v.get('parent') == parent_uuid and has_matching_visible_name:
                 wildcard_matches.append(k)
 
@@ -1082,8 +1113,7 @@ class RemarkableWorkspace:
         :return: True, if entry with identical visibleName exists
         """
 
-        entry_visible_name: str = (self.get_data_for_uuid(entry_uuid)
-                                   .get('visibleName'))
+        entry_visible_name: str = self.get_data_for_uuid(entry_uuid)['visibleName']
 
         return self._has_visible_name_equal_to_entry_uuid_in_collection(
             entry_uuid, entry_visible_name, target_collection_uuid)
@@ -1172,7 +1202,7 @@ class RemarkableWorkspace:
         raise NotFoundError(f"cannot access {path_prefix}/{filename}: "
                                 f"{NO_SUCH_FILE_OR_DIRECTORY}")
 
-    def _entry_is_a_collection(self, entity_uuid) -> bool:
+    def _entry_is_a_collection(self, entity_uuid: str) -> bool:
         """
         Validates whether the metadata entry with the given UUID
         is of type CollectionType.

--- a/test/data/test_metdata_source.py
+++ b/test/data/test_metdata_source.py
@@ -12,7 +12,7 @@ from test.test_data import TEST_DATA, UUID_FAIRYTALE
 class TestMetadataSource(unittest.TestCase):
 
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.source = MetadataSource()
 
 
@@ -21,10 +21,11 @@ class TestMetadataSource(unittest.TestCase):
             self.source.load()
 
     def test_write_raises_not_implemented_error(self) -> None:
+
         with self.assertRaises(NotImplementedError) as ctx:
             self.source.write_metadata(
                 UUID_FAIRYTALE,
-                Metadata.from_dict(TEST_DATA.get(UUID_FAIRYTALE)))
+                Metadata.from_dict(TEST_DATA[UUID_FAIRYTALE]))
 
     def test_remove_raises_not_implemented_error(self) -> None:
         with self.assertRaises(NotImplementedError) as ctx:

--- a/test/data/test_remarkable_ssh_metadata_source.py
+++ b/test/data/test_remarkable_ssh_metadata_source.py
@@ -33,7 +33,7 @@ import tarfile
 import time
 import unittest
 from io import BytesIO
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Any
 from unittest.mock import patch, MagicMock
 
 from src.constant import SSH_CONNECT, REMOTE_PREFIX
@@ -50,14 +50,14 @@ SUT: str = "src.data.remarkable_ssh_metadata_source"
 
 class TestRemarkableSSHMetadataSource(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.source = RemarkableSSHMetadataSource()
 
     # --------------------------------------------------
     # Helpers
     # --------------------------------------------------
 
-    def _create_tar_bytes(self, files: dict[str, dict]) -> bytes:
+    def _create_tar_bytes(self, files: Dict[str, Dict[Any, Any]]) -> bytes:
         """
         Create an in-memory tar archive containing *.metadata files.
         `files` is a dict of uuid -> metadata_dict
@@ -77,7 +77,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
 
     @patch.object(RemarkableSSHMetadataSource, "_get_file_sizes")
     @patch.object(RemarkableSSHMetadataSource, "_fetch_metadata")
-    def test_load_merges_sizes(self, mock_fetch, mock_sizes):
+    def test_load_merges_sizes(self, mock_fetch: MagicMock, mock_sizes: MagicMock) -> None:
         mock_fetch.return_value = {
             "uuid1": {"name": "doc1"},
             "uuid2": {"name": "doc2"},
@@ -98,7 +98,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
 
     @patch("subprocess.Popen")
     @patch.object(RemarkableSSHMetadataSource, "_get_file_sizes")
-    def test_fetch_metadata_success(self, mock_sizes, mock_popen):
+    def test_fetch_metadata_success(self, mock_sizes: MagicMock, mock_popen: MagicMock) -> None:
         tar_bytes = self._create_tar_bytes({
             "uuid1": {"name": "doc1"},
             "uuid2": {"name": "doc2"},
@@ -125,7 +125,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
         self.assertNotIn("size", result["uuid2"])
 
     @patch("subprocess.Popen")
-    def test_fetch_metadata_nonzero_returncode_raises(self, mock_popen):
+    def test_fetch_metadata_nonzero_returncode_raises(self, mock_popen: MagicMock) -> None:
         mock_proc = MagicMock()
 
         # Make context manager return the same object
@@ -141,7 +141,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
         self.assertIn("error", str(ctx.exception))
 
     @patch("subprocess.Popen")
-    def test_fetch_metadata_no_tar_bytes_raises(self, mock_popen):
+    def test_fetch_metadata_no_tar_bytes_raises(self, mock_popen: MagicMock) -> None:
         mock_proc = MagicMock()
         # Make context manager return the same object
         mock_proc.__enter__.return_value = mock_proc
@@ -157,7 +157,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
 
     @patch("subprocess.Popen")
     @patch.object(RemarkableSSHMetadataSource, "_get_file_sizes")
-    def test_fetch_metadata_invalid_json_skipped(self, mock_sizes, mock_popen):
+    def test_fetch_metadata_invalid_json_skipped(self, mock_sizes: MagicMock, mock_popen: MagicMock) -> None:
         # Create tar with one invalid JSON file
         tar_buffer = BytesIO()
         with tarfile.open(fileobj=tar_buffer, mode="w:") as tar:
@@ -186,7 +186,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
     # --------------------------------------------------
 
     @patch("subprocess.Popen")
-    def test_get_file_sizes_success(self, mock_popen):
+    def test_get_file_sizes_success(self, mock_popen: MagicMock) -> None:
         mock_proc = MagicMock()
         # Make context manager return the same object
         mock_proc.__enter__.return_value = mock_proc
@@ -204,7 +204,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
         self.assertEqual(result["uuid2"], 200)
 
     @patch("subprocess.Popen")
-    def test_get_file_sizes_nonzero_return_code_raises(self, mock_popen):
+    def test_get_file_sizes_nonzero_return_code_raises(self, mock_popen: MagicMock) -> None:
         mock_proc = MagicMock()
         # Make context manager return the same object
         mock_proc.__enter__.return_value = mock_proc
@@ -223,7 +223,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
     # --------------------------------------------------
 
     @patch("subprocess.Popen")
-    def test_metadata_write_operation_succeeds(self, mock_popen) -> None:
+    def test_metadata_write_operation_succeeds(self, mock_popen: MagicMock) -> None:
         # And assuming the process finished successfully
         mock_proc = MagicMock()
         mock_proc.communicate.return_value = ("", "")
@@ -252,7 +252,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
         mock_proc.communicate.assert_called_once_with(expected_content)
 
     @patch("subprocess.Popen")
-    def test_metadata_write_fails_with_returncode(self, mock_popen) -> None:
+    def test_metadata_write_fails_with_returncode(self, mock_popen: MagicMock) -> None:
         # And assuming the process finished successfully
         mock_proc = MagicMock()
         mock_proc.communicate.return_value = ("", "")
@@ -268,7 +268,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
         self.assertTrue("Failed to write metadata" in str(context.exception))
 
     @patch("subprocess.Popen", side_effect=OSError('test'))
-    def test_metadata_write_fails_due_to_os_error(self, mock_popen) -> None:
+    def test_metadata_write_fails_due_to_os_error(self, mock_popen: MagicMock) -> None:
         with self.assertRaises(RemarkableWriteError) as context:
             self.call_write_metadata_to_remarkable_with_valid_data()
 
@@ -300,7 +300,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
     # --------------------------------------------------
 
     @patch("subprocess.Popen")
-    def test_remove_positive_case(self, mock_popen) -> None:
+    def test_remove_positive_case(self, mock_popen: MagicMock) -> None:
         # Assuming popen process finished successfully
         mock_proc = MagicMock()
         mock_proc.communicate.return_value = ("", "")
@@ -325,14 +325,14 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
         )
 
     @patch("subprocess.Popen", side_effect=OSError('test'))
-    def test_remove_fails_due_to_os_error(self, mock_popen) -> None:
+    def test_remove_fails_due_to_os_error(self, mock_popen: MagicMock) -> None:
         with self.assertRaises(RemarkableWriteError) as context:
             self.source.remove([UUID_FAIRYTALE])
 
         self.assertTrue("OS error while removing files:" in str(context.exception))
 
     @patch("subprocess.Popen")
-    def test_remove_fails_due_process_error_code(self, mock_popen) -> None:
+    def test_remove_fails_due_process_error_code(self, mock_popen: MagicMock) -> None:
         # And assuming the process finished successfully
         mock_proc = MagicMock()
         mock_proc.communicate.return_value = ("", "")
@@ -350,7 +350,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
     # --------------------------------------------------
 
     @patch(f"{SUT}.subprocess.Popen")
-    def test_remote_copy_success(self, mock_popen) -> None:
+    def test_remote_copy_success(self, mock_popen: MagicMock) -> None:
         # ---- Mock processes ----
         mock_tar_proc = MagicMock()
         mock_ssh_proc = MagicMock()
@@ -410,7 +410,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
         self.assertEqual(ssh_kwargs["stdin"], mock_tar_proc.stdout)
 
     @patch(f"{SUT}.subprocess.Popen")
-    def test_remote_copy_ssh_failure(self, mock_popen) -> None:
+    def test_remote_copy_ssh_failure(self, mock_popen: MagicMock) -> None:
         # ---- Mock processes ----
         mock_tar_proc = MagicMock()
         mock_ssh_proc = MagicMock()
@@ -468,7 +468,7 @@ class TestRemarkableSSHMetadataSource(unittest.TestCase):
     # --------------------------------------------------
 
     @patch("src.data.remarkable_ssh_metadata_source.subprocess.run")
-    def test_restart_xochitl_success(self, mock_run) -> None:
+    def test_restart_xochitl_success(self, mock_run: MagicMock) -> None:
         # ---- Mock subprocess result ----
         mock_result = MagicMock()
         mock_result.returncode = 0

--- a/test/dto/test_content.py
+++ b/test/dto/test_content.py
@@ -20,14 +20,14 @@ class TestContent(unittest.TestCase):
 
     def test_content_with_file_type_none_raises_exception(self) -> None:
         with self.assertRaises(InvalidContentError) as context:
-            Content(file_type=None)
+            Content(file_type=None) # type: ignore[arg-type]
 
         self.assertTrue("fileType for content file must be an Enum FileType"
                         in str(context.exception), msg=context.exception)
 
     def test_content_with_file_type_str_raises_exception(self) -> None:
         with self.assertRaises(InvalidContentError) as context:
-            Content(file_type="pdf")
+            Content(file_type="pdf") # type: ignore[arg-type]
 
         self.assertTrue("fileType for content file must be an Enum FileType"
                         in str(context.exception), msg=context.exception)

--- a/test/dto/test_metadata.py
+++ b/test/dto/test_metadata.py
@@ -3,6 +3,7 @@
 """
 import time
 import unittest
+from pydoc import visiblename
 
 from src.dto.entry_type_enum import EntityType
 from src.dto.metadata import Metadata
@@ -73,7 +74,7 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(InvalidMetadataError) as context:
             Metadata(
                 created_time=int(time.time() * 1000),
-                last_modified=None,
+                last_modified=None, # type: ignore[arg-type]
                 new=False,
                 parent='d433121d-b050-4740-8db7-0ed11b980371',
                 pinned=False,
@@ -90,7 +91,7 @@ class TestMetadata(unittest.TestCase):
             Metadata(
                 created_time=int(time.time() * 1000),
                 last_modified=int(time.time() * 1000),
-                new=None,
+                new=None, # type: ignore[arg-type]
                 parent='d433121d-b050-4740-8db7-0ed11b980371',
                 pinned=False,
                 source='',
@@ -105,7 +106,7 @@ class TestMetadata(unittest.TestCase):
             Metadata(
                 created_time=int(time.time() * 1000),
                 last_modified=int(time.time() * 1000),
-                new='False',
+                new='False', # type: ignore[arg-type]
                 parent='d433121d-b050-4740-8db7-0ed11b980371',
                 pinned=False,
                 source='',
@@ -121,7 +122,7 @@ class TestMetadata(unittest.TestCase):
                 created_time=int(time.time() * 1000),
                 last_modified=int(time.time() * 1000),
                 new=False,
-                parent=None,
+                parent=None,# type: ignore[arg-type]
                 pinned=False,
                 source='',
                 type=EntityType.DOCUMENT_TYPE,
@@ -152,7 +153,7 @@ class TestMetadata(unittest.TestCase):
                 last_modified=int(time.time() * 1000),
                 new=False,
                 parent='d433121d-b050-4740-8db7-0ed11b980371',
-                pinned="False",
+                pinned="False", # type: ignore[arg-type]
                 source='',
                 type=EntityType.DOCUMENT_TYPE,
                 visible_name='secret-algorithms.pdf'
@@ -167,7 +168,7 @@ class TestMetadata(unittest.TestCase):
                 new=False,
                 parent='d433121d-b050-4740-8db7-0ed11b980371',
                 pinned=False,
-                source=None,
+                source=None, # type: ignore[arg-type]
                 type=EntityType.DOCUMENT_TYPE,
                 visible_name='secret-algorithms.pdf'
             )
@@ -182,7 +183,7 @@ class TestMetadata(unittest.TestCase):
                 parent='d433121d-b050-4740-8db7-0ed11b980371',
                 pinned=False,
                 source='',
-                type='DocumentType',
+                type='DocumentType', # type: ignore[arg-type]
                 visible_name='secret-algorithms.pdf'
             )
         self.assertTrue("type" in str(context.exception))
@@ -198,7 +199,7 @@ class TestMetadata(unittest.TestCase):
                 pinned=False,
                 source='',
                 type=EntityType.DOCUMENT_TYPE,
-                visible_name=None
+                visible_name=None # type: ignore[arg-type]
             )
         self.assertTrue("visibleName" in str(context.exception))
 
@@ -208,26 +209,35 @@ class TestMetadata(unittest.TestCase):
 
         time_now = int(time.time() * 1000)
 
+        created_time = time_now
+        last_modified = time_now
+        new = False
+        parent = 'd433121d-b050-4740-8db7-0ed11b980371'
+        pinned = False
+        source = ''
+        type_value = EntityType.COLLECTION_TYPE
+        visiblename_value = 'secret_algorithms'
+
         expected_dict = {
-            "createdTime": time_now,
-            "lastModified": time_now,
-            "new": False,
-            "parent": 'd433121d-b050-4740-8db7-0ed11b980371',
-            "pinned": False,
-            "source": '',
-            "type": EntityType.COLLECTION_TYPE,
-            "visibleName": 'secret_algorithms',
+            "createdTime": created_time,
+            "lastModified": last_modified,
+            "new": new,
+            "parent": parent,
+            "pinned": pinned,
+            "source": source,
+            "type": type_value,
+            "visibleName": visiblename_value,
         }
 
         metadata = Metadata(
-            created_time=expected_dict.get('createdTime'),
-            last_modified=expected_dict.get('lastModified'),
-            new=expected_dict.get('new'),
-            parent=expected_dict.get('parent'),
-            pinned=expected_dict.get('pinned'),
-            source=expected_dict.get('source'),
-            type=expected_dict.get('type'),
-            visible_name=expected_dict.get('visibleName')
+            created_time=created_time,
+            last_modified=last_modified,
+            new=new,
+            parent=parent,
+            pinned=pinned,
+            source=source,
+            type=type_value,
+            visible_name=visiblename_value
         )
 
         self.assertEqual(expected_dict, metadata.to_dict())
@@ -243,7 +253,7 @@ class TestMetadata(unittest.TestCase):
                 source='',
                 type=EntityType.DOCUMENT_TYPE,
                 visible_name='secret-algorithms.pdf'
-            )
+            ) # type: ignore[call-arg]
 
         self.assertTrue("parent" in str(context.exception))
 

--- a/test/stub_remarkable_metadata_source.py
+++ b/test/stub_remarkable_metadata_source.py
@@ -2,6 +2,7 @@
     Module for stubbing reMarkable datasource
 """
 from test.test_data import TEST_DATA
+from typing import Any, Dict
 
 from src.data.metadata_source import  MetadataSource
 
@@ -11,5 +12,5 @@ class StubRemarkableMetadataSource(MetadataSource):
     A class implementation of the stub
     """
 
-    def load(self):
+    def load(self) -> Dict[str, Any]:
         return TEST_DATA

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -4,7 +4,7 @@
     updating test data may break existing test cases.
 """
 
-from typing import Dict
+from typing import Dict, Any
 
 UUID_ROOT = ''
 # CollectionType A and its descendants
@@ -25,7 +25,7 @@ UUID_A_UNDER_B = "b21ca949-1d94-4b61-afd8-59bcf7330721"
 UUID_A0_UNDER_B = "40b7fe05-1c55-4944-b434-74e3f1c48bff"
 UUID_D_1 = "0cee4351-e773-4f83-858d-0e4f52c82627"
 
-TEST_DATA: Dict[str, Dict[str, str]] = {
+TEST_DATA: Dict[str, Dict[str, Any]] = {
     UUID_A: {
         "type": "CollectionType",
         "parent": "",

--- a/test/workspace/test_remarkable_workspace.py
+++ b/test/workspace/test_remarkable_workspace.py
@@ -25,7 +25,7 @@ from test.test_data import (
 class RemarkableWorkspaceTest(unittest.TestCase):
 
     @patch.object(RemarkableSSHMetadataSource, "load")
-    def setUp(self, mock_load) -> None:
+    def setUp(self, mock_load: MagicMock) -> None:
         mock_load.return_value = copy.deepcopy(TEST_DATA)
         self.ws = RemarkableWorkspace(RemarkableSSHMetadataSource())
 
@@ -199,7 +199,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
             self.assertTrue(f"mv: /C: {NO_SUCH_FILE_OR_DIRECTORY}" in output, msg=f"Output was: {output}")
 
     @patch.object(RemarkableSSHMetadataSource, "write_metadata")
-    def test_document_with_invalid_metadata_cannot_be_moved_and_error_is_shown(self, mock_write) -> None:
+    def test_document_with_invalid_metadata_cannot_be_moved_and_error_is_shown(self, mock_write: MagicMock) -> None:
         mock_write.return_value = None
         self.ws.set_current_collection(UUID_A)
         with patch('sys.stdout', new=StringIO()) as mock_out:
@@ -449,7 +449,8 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         self.assertEqual(mock_write.call_count, 1)
         self.assertIsNotNone(self.ws.get_data().get(actual_path_uuid),
                              msg=f"UUID {actual_path_uuid} not found in data")
-        actual_visible_name = self.ws.get_data().get(actual_path_uuid).get('visibleName')
+        actual_dict = self.ws.get_data()[actual_path_uuid]
+        actual_visible_name = actual_dict['visibleName']
         self.assertEqual(actual_path_to_make, actual_visible_name,
                          msg=f"visibleName {actual_visible_name} does not match path {actual_path_to_make}")
 
@@ -589,7 +590,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         mock_exists.return_value = True
         mock_load.return_value = ["new_data"]
 
-        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT)
+        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT) # type: ignore[method-assign]
 
         source_file = "/path/to/file.pdf"
         target_path = "/"
@@ -639,7 +640,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         mock_walk.return_value = [(source_path, [], ["file1.pdf", "file2.epub"])]
         mock_load.return_value = ["new_data"]
 
-        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT)
+        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT) # type: ignore[method-assign]
 
         target_path = "/"
 
@@ -698,7 +699,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         mock_walk.return_value = [(source_path, [], ["file1.pdf", "path1/file2.epub"])]
         mock_load.return_value = ["new_data"]
 
-        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT)
+        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT) # type: ignore[method-assign]
 
         target_path = "/"
 
@@ -758,7 +759,7 @@ class RemarkableWorkspaceTest(unittest.TestCase):
         mock_walk.return_value = [(source_path, [], [])]
         mock_load.return_value = ["new_data"]
 
-        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT)
+        self.ws._traverse_path = MagicMock(return_value=UUID_ROOT) # type: ignore[method-assign]
 
         target_path = "/"
 
@@ -839,13 +840,13 @@ class RemarkableWorkspaceTest(unittest.TestCase):
     # Process refresh command
     # -------------------------------------
     @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
-    def test_refresh_invokes_metadata_source(self, mock_restart) -> None:
+    def test_refresh_invokes_metadata_source(self, mock_restart: MagicMock) -> None:
 
         self.ws.restart_xochitl()
         mock_restart.assert_called_once()
 
     @patch.object(RemarkableSSHMetadataSource, "restart_xochitl")
-    def test_refresh_raises_exception_when_refresh_fails(self, mock_restart) -> None:
+    def test_refresh_raises_exception_when_refresh_fails(self, mock_restart: MagicMock) -> None:
         mock_restart.side_effect = RemarkableOperationError("failure")
 
         with self.assertRaises(RemarkableOperationError) as context:


### PR DESCRIPTION
## Summary of changes 

The main purpose of this PR is to add logging feature to the reMarkable Virtual FileSystem. The purpose of logging is to support in development process and its focus should always remain on that. No information relevant to end user should ever be passed in a log message. 

Logging can be now enabled with arguments. To turn logging on using the default log level INFO: 

```bash
$ python3 remarkable-vfs.py --log 
```

To specify the log level:

```bash
$ python3 remarkable-vfs.py --log  --log-level DEBUG
```

More information on arguments: 


```bash
$ python3 remarkable-vfs.py --help
```

In addition to logging the project now uses `mypy` in strict mode. So in addition to type hinting now the project requires type checking. I will add type checking to the quality gate Github Action in future and to the DoD checklist. The expectation is that each new PR contains no errors according to `mypy`. Under critical consideration exceptions can be made (errors can be ignored), but each such case should be reviewed with extreme scrutiny. :) 


## DoD checklist

Please check all items that have been addressed: 

- [x] development is based on a ticket detailing what is being done
  - [x] related ticket explains the motivation for the changes and the objectives based on which developers can reason when the issue has been fully resolved
  - [x] development was done in feature branch linked to the ticket
  - [x] all commits refer to the ticket
- [x]  new code is tested
  - [x] test coverage exceeds 80 percent 
  - [x] new functionality has been end-to-end tested
- [x]  new code has docstring or other documentation
- [x] new functionality has been documented and existing documentation has been updated
- [x] pylint score is 9.5 or higher
- [x] there are no open `mypy` errors 
- [x] Included instructions on how to manually test any new functionality
- [x] Updated template for test report with new test cases 

## How to test

**TC1.** Logging with default level

Launch the application with

```bash
$ python3 remarkable-vfs.py --log 
```
Confirm that the default log level is used (INFO). 

**TC2.** Specifying the log level

Launch the application with
```bash
$ python3 remarkable-vfs.py --log  --log-level DEBUG
```
Confirm that the log level DEBUG is used. Also try this with other supported log levels. 

**TC3.** No logging 
Launch the application with
```bash
$ python3 remarkable-vfs.py
```
Confirm that logging is disabled